### PR TITLE
Several changes on brain-score, candidate_models, and model-tools for screen degrees branch

### DIFF
--- a/brainscore/__init__.py
+++ b/brainscore/__init__.py
@@ -7,7 +7,8 @@ def get_assembly(name):
     if not hasattr(assembly.stimulus_set, 'name'):
         assembly.stimulus_set.name = assembly.stimulus_set_name
 
-    stimulus_set_degrees = {'dicarlo.hvm': 8, 'movshon.FreemanZiemba2013': 4}
+    stimulus_set_degrees = {'dicarlo.hvm': 8, 'movshon.FreemanZiemba2013': 4, 'tolias.Cadena2017': 2,
+                            'dicarlo.objectome.private': 6, 'dicarlo.objectome.public': 6}
     if assembly.stimulus_set.name in stimulus_set_degrees:
         assembly.stimulus_set['degrees'] = stimulus_set_degrees[assembly.stimulus_set.name]
     return assembly

--- a/brainscore/__init__.py
+++ b/brainscore/__init__.py
@@ -8,7 +8,7 @@ def get_assembly(name):
         assembly.stimulus_set.name = assembly.stimulus_set_name
 
     stimulus_set_degrees = {'dicarlo.hvm': 8, 'movshon.FreemanZiemba2013': 4, 'tolias.Cadena2017': 2,
-                            'dicarlo.objectome.private': 6, 'dicarlo.objectome.public': 6}
+                            'dicarlo.objectome.private': 8, 'dicarlo.objectome.public': 8}
     if assembly.stimulus_set.name in stimulus_set_degrees:
         assembly.stimulus_set['degrees'] = stimulus_set_degrees[assembly.stimulus_set.name]
     return assembly

--- a/brainscore/benchmarks/behavioral.py
+++ b/brainscore/benchmarks/behavioral.py
@@ -8,12 +8,13 @@ from brainscore.assemblies.private import load_assembly
 from brainscore.metrics.behavior import I2n
 from brainscore.metrics.transformations import apply_aggregate
 from brainscore.model_interface import BrainModel
-
+from brainscore.benchmarks.screen import place_on_screen
 
 class DicarloRajalingham2018I2n(BenchmarkBase):
     def __init__(self):
         self._metric = I2n()
         self._fitting_stimuli = brainscore.get_stimulus_set('dicarlo.objectome.public')
+        self._fitting_stimuli['degrees'] = 6
         self._assembly = load_assembly('dicarlo.Rajalingham2018')
         super(DicarloRajalingham2018I2n, self).__init__(
             identifier='dicarlo.Rajalingham2018-i2n',
@@ -22,8 +23,10 @@ class DicarloRajalingham2018I2n(BenchmarkBase):
             paper_link='https://www.biorxiv.org/content/early/2018/02/12/240614')
 
     def __call__(self, candidate: BrainModel):
-        candidate.start_task(BrainModel.Task.probabilities, self._fitting_stimuli)
-        probabilities = candidate.look_at(self._assembly.stimulus_set)
+        fitting_stimuli = place_on_screen(self._fitting_stimuli, target_visual_degrees=candidate.visual_degrees())
+        candidate.start_task(BrainModel.Task.probabilities, fitting_stimuli)
+        stimulus_set = place_on_screen(self._assembly.stimulus_set, target_visual_degrees=candidate.visual_degrees())
+        probabilities = candidate.look_at(stimulus_set)
         score = self._metric(probabilities, self._assembly)
         score = self.ceil_score(score, self.ceiling)
         return score

--- a/brainscore/benchmarks/behavioral.py
+++ b/brainscore/benchmarks/behavioral.py
@@ -14,7 +14,7 @@ class DicarloRajalingham2018I2n(BenchmarkBase):
     def __init__(self):
         self._metric = I2n()
         self._fitting_stimuli = brainscore.get_stimulus_set('dicarlo.objectome.public')
-        self._fitting_stimuli['degrees'] = 6
+        self._fitting_stimuli['degrees'] = 8
         self._assembly = load_assembly('dicarlo.Rajalingham2018')
         super(DicarloRajalingham2018I2n, self).__init__(
             identifier='dicarlo.Rajalingham2018-i2n',


### PR DESCRIPTION
~Removes cropping images to 85% for tensorflow models in preprocessing.~
Adds stimulus size of 6deg for behavioral benchmark.
Adds stimilus size of 2deg for Cadena benchmark.
~Allows behavior benchmark to work on models with multiple layers.~

