### PR TITLE
avoid adding new dimension on score.raw for existing coordinate level

### DIFF
--- a/brainscore/metrics/transformations.py
+++ b/brainscore/metrics/transformations.py
@@ -148,8 +148,9 @@ class CartesianProduct(Transformation):
                 # expand and set coordinate value. If the underlying raw values already contain that coordinate
                 # (e.g. as part of a MultiIndex), don't create and set new dimension on raw values.
                 apply_raw = hasattr(result, 'raw') and not hasattr(result.raw, coord_name)
-                result = result.expand_dims(coord_name, _apply_raw=apply_raw)
-                result.__setitem__(coord_name, [coord_value], _apply_raw=apply_raw)
+                kwargs = dict(_apply_raw=apply_raw) if apply_raw else {}
+                result = result.expand_dims(coord_name, **kwargs)
+                result.__setitem__(coord_name, [coord_value], **kwargs)
             scores.append(result)
         scores = Score.merge(*scores)
         yield scores

--- a/brainscore/metrics/transformations.py
+++ b/brainscore/metrics/transformations.py
@@ -145,8 +145,11 @@ class CartesianProduct(Transformation):
             result = yield from self._get_result(divided_assembly, done=done)
 
             for coord_name, coord_value in divider.items():
-                result = result.expand_dims(coord_name)
-                result[coord_name] = [coord_value]
+                apply_raw = not hasattr(result.raw, coord_name)
+                # expand and set coordinate value. If the underlying raw values already contain that coordinate
+                # (e.g. as part of a MultiIndex), don't create and set new dimension.
+                result = result.expand_dims(coord_name, _apply_raw=apply_raw)
+                result.__setitem__(coord_name, [coord_value], _apply_raw=apply_raw)
             scores.append(result)
         scores = Score.merge(*scores)
         yield scores

--- a/brainscore/metrics/transformations.py
+++ b/brainscore/metrics/transformations.py
@@ -145,9 +145,9 @@ class CartesianProduct(Transformation):
             result = yield from self._get_result(divided_assembly, done=done)
 
             for coord_name, coord_value in divider.items():
-                apply_raw = not hasattr(result.raw, coord_name)
                 # expand and set coordinate value. If the underlying raw values already contain that coordinate
-                # (e.g. as part of a MultiIndex), don't create and set new dimension.
+                # (e.g. as part of a MultiIndex), don't create and set new dimension on raw values.
+                apply_raw = hasattr(result, 'raw') and not hasattr(result.raw, coord_name)
                 result = result.expand_dims(coord_name, _apply_raw=apply_raw)
                 result.__setitem__(coord_name, [coord_value], _apply_raw=apply_raw)
             scores.append(result)


### PR DESCRIPTION
this fixes a problem where, if a coordinate already exists as part of a MultiIndex, it is additionally added as a dimension, and then multiple such assemblies cannot be merged together