### PR TITLE
add Kar2018{hvm,cocogray} benchmarks

### DIFF
--- a/brainscore/benchmarks/kar2018.py
+++ b/brainscore/benchmarks/kar2018.py
@@ -1,0 +1,41 @@
+import brainscore
+from brainscore.benchmarks._neural_common import NeuralBenchmark, average_repetition
+from brainscore.metrics.ceiling import InternalConsistency
+from brainscore.metrics.regression import CrossRegressedCorrelation, pls_regression, pearsonr_correlation
+from brainscore.utils import LazyLoad
+
+
+def DicarloKar2018hvmPLS():
+    assembly_repetition = LazyLoad(lambda: load_assembly(stimuli='hvm', average_repetitions=False))
+    assembly = LazyLoad(lambda: load_assembly(stimuli='hvm', average_repetitions=True))
+    similarity_metric = CrossRegressedCorrelation(
+        regression=pls_regression(), correlation=pearsonr_correlation(),
+        crossvalidation_kwargs=dict(stratification_coord='object_name'))
+    ceiler = InternalConsistency()
+    return NeuralBenchmark(identifier=f'dicarlo.Kar2018hvm-pls', version=1,
+                           assembly=assembly, similarity_metric=similarity_metric,
+                           ceiling_func=lambda: ceiler(assembly_repetition),
+                           parent='IT', paper_link=None)
+
+
+def DicarloKar2018cocoPLS():
+    assembly_repetition = LazyLoad(lambda: load_assembly(stimuli='cocogray', average_repetitions=False))
+    assembly = LazyLoad(lambda: load_assembly(stimuli='cocogray', average_repetitions=True))
+    similarity_metric = CrossRegressedCorrelation(
+        regression=pls_regression(), correlation=pearsonr_correlation(),
+        crossvalidation_kwargs=dict(stratification_coord='label'))
+    ceiler = InternalConsistency()
+    return NeuralBenchmark(identifier=f'dicarlo.Kar2018coco-pls', version=1,
+                           assembly=assembly, similarity_metric=similarity_metric,
+                           ceiling_func=lambda: ceiler(assembly_repetition),
+                           parent='IT', paper_link=None)
+
+
+def load_assembly(stimuli, average_repetitions):
+    assembly = brainscore.get_assembly(name=f'dicarlo.Kar2018{stimuli}')
+    assembly = assembly.squeeze("time_bin")
+    assembly.load()
+    assembly = assembly.transpose('presentation', 'neuroid')
+    if average_repetitions:
+        assembly = average_repetition(assembly)
+    return assembly

--- a/tests/test_benchmarks/test___init__.py
+++ b/tests/test_benchmarks/test___init__.py
@@ -28,6 +28,10 @@ class TestStandardized:
                      marks=pytest.mark.memory_intense),
         pytest.param('dicarlo.Majaj2015.IT-rdm', approx(.887618, abs=.001),
                      marks=pytest.mark.memory_intense),
+        pytest.param('dicarlo.Kar2018hvm-pls', approx(.842015, abs=.001),
+                     marks=pytest.mark.memory_intense),
+        pytest.param('dicarlo.Kar2018coco-pls', approx(.795665, abs=.001),
+                     marks=pytest.mark.memory_intense),
     ])
     def test_ceilings(self, benchmark, expected):
         benchmark = benchmark_pool[benchmark]
@@ -44,6 +48,10 @@ class TestStandardized:
         pytest.param('dicarlo.Majaj2015.V4-pls', approx(.923713, abs=.001),
                      marks=pytest.mark.memory_intense),
         pytest.param('dicarlo.Majaj2015.IT-pls', approx(.823433, abs=.001),
+                     marks=pytest.mark.memory_intense),
+        pytest.param('dicarlo.Kar2018hvm-pls', approx(.823433, abs=.001),
+                     marks=pytest.mark.memory_intense),
+        pytest.param('dicarlo.Kar2018coco-pls', approx(.856989, abs=.001),
                      marks=pytest.mark.memory_intense),
     ])
     def test_self_regression(self, benchmark, expected):
@@ -93,6 +101,16 @@ class TestPrecomputed:
     ])
     def test_Majaj2015(self, benchmark, expected):
         self.run_test(benchmark=benchmark, file='alexnet-majaj2015.private-features.12.pkl', expected=expected)
+
+    @pytest.mark.memory_intense
+    def test_Kar2018hvm(self):
+        self.run_test(benchmark='dicarlo.Kar2018hvm-pls', file='alexnet-hvm-features.12.pkl',
+                      expected=approx(.490236, abs=.005))
+
+    @pytest.mark.memory_intense
+    def test_Kar2018coco(self):
+        self.run_test(benchmark='dicarlo.Kar2018coco-pls', file='alexnet-cocogray-features.12.pkl',
+                      expected=approx(.490236, abs=.005))
 
     @pytest.mark.memory_intense
     @pytest.mark.requires_gpu


### PR DESCRIPTION
not all unit tests pass. Precomputed features don't work yet because the StimulusSet differs (see https://github.com/brain-score/brainio_contrib/pull/24), and the later numbers have not yet been run