### PR TITLE
fix Rajalingham2018public benchmark ceiling and verify with unit test

### DIFF
--- a/brainscore/benchmarks/public_benchmarks.py
+++ b/brainscore/benchmarks/public_benchmarks.py
@@ -64,6 +64,7 @@ class RajalinghamMatchtosamplePublicBenchmark(DicarloRajalingham2018I2n):
     def __init__(self):
         super(RajalinghamMatchtosamplePublicBenchmark, self).__init__()
         self._assembly = LazyLoad(lambda: load_rajalingham2018(access='public'))
+        self._ceiling_func = lambda: self._metric.ceiling(self._assembly, skipna=True)
 
 
 def list_public_assemblies():

--- a/tests/download_test_files.sh
+++ b/tests/download_test_files.sh
@@ -3,7 +3,7 @@
 # get directory of this script (i.e. tests), following https://stackoverflow.com/a/246128/2225200
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-for f in alexnet-freemanziemba2013.aperture-private.pkl alexnet-majaj2015.private-features.12.pkl cornet_s-kar2019.pkl
+for f in alexnet-freemanziemba2013.aperture-private.pkl alexnet-majaj2015.private-features.12.pkl CORnetZ-rajalingham2018public.pkl cornet_s-kar2019.pkl
 do
   aws --no-sign-request s3 cp s3://brain-score-tests/tests/test_benchmarks/${f} ${SCRIPT_DIR}/test_benchmarks/
 done

--- a/tests/test_benchmarks/__init__.py
+++ b/tests/test_benchmarks/__init__.py
@@ -12,6 +12,9 @@ class PrecomputedFeatures(BrainModel):
     def visual_degrees(self) -> int:
         return self._visual_degrees
 
+    def start_task(self, task, fitting_stimuli=None):
+        pass
+
     def start_recording(self, region, *args, **kwargs):
         pass
 

--- a/tests/test_benchmarks/test___init__.py
+++ b/tests/test_benchmarks/test___init__.py
@@ -165,6 +165,19 @@ class TestPrecomputed:
         score = benchmark(precomputed_features).raw
         assert score.sel(aggregation='center') == approx(.316, abs=.005)
 
+    def test_Rajalingham2018public(self):
+        # load features
+        precomputed_features = Path(__file__).parent / 'CORnetZ-rajalingham2018public.pkl'
+        with open(precomputed_features, 'rb') as f:
+            precomputed_features = pickle.load(f)['data']
+        precomputed_features = PrecomputedFeatures(precomputed_features,
+                                                   visual_degrees=8,  # doesn't matter, features are already computed
+                                                   )
+        # score
+        benchmark = benchmark_pool['dicarlo.Rajalingham2018public-i2n']
+        score = benchmark(precomputed_features).raw
+        assert score.sel(aggregation='center') == approx(.136923, abs=.005)
+
 
 class TestVisualDegrees:
     @pytest.mark.parametrize('benchmark, candidate_degrees, image_id, expected', [


### PR DESCRIPTION
The public data does not have a full set of trials for all image/distractor pairs and as a result, there are some nans in the data which didn't let us compute the ceiling. We already had code to deal with it, it was just a matter of turning on the necessary flag to ignore nans in the split-half source of the metric.