### PR TITLE
move high-level documentation from .rst into code

### DIFF
--- a/brainscore/benchmarks/__init__.py
+++ b/brainscore/benchmarks/__init__.py
@@ -1,3 +1,10 @@
+"""
+A :class:`~brainscore.benchmarks.Benchmark` runs an experiment on a :class:`~brainscore.model_interface.BrainModel`
+and tests the resulting measurements against primate `data <https://github.com/brain-score/brainio_collection>`_.
+This comparison is done by a :class:`~brainscore.metrics.Metric` which outputs a score of how well model and data match.
+This score is normalized with data ceilings and the benchmark returns this ceiled score.
+"""
+
 import itertools
 from abc import ABC
 

--- a/brainscore/metrics/__init__.py
+++ b/brainscore/metrics/__init__.py
@@ -1,6 +1,8 @@
 """
-Metrics are a part of :class:`~brainscore.benchmarks.Benchmark`s and score how similar two sets of data are.
-Typically these two sets are model and primate measurements, but metrics are agnostic of the data source.
+a :class:`~brainscore.metrics.Metric` is part of a :class:`~brainscore.benchmarks.Benchmark`
+and scores how similar two sets of data are.
+Typically these two sets are model and primate measurements, but metrics are agnostic of the data source
+and can also be used to compare two primate measurements (e.g. for ceiling estimates).
 """
 
 import warnings
@@ -33,6 +35,13 @@ _logger = logging.getLogger(__name__)  # cannot set directly on Score object
 
 
 class Score(DataAssembly):
+    """
+    Scores are used as the outputs of metrics, benchmarks, and ceilings. They indicate similarity or goodness-of-fit
+    of sets of data. The high-level score is typically an aggregate of many smaller scores, e.g. the median of neuroid
+    correlations. To keep records of these smaller scores, a score can store "raw" scores in its attributes
+    (`score.attrs['raw']`).
+    """
+
     RAW_VALUES_KEY = 'raw'
 
     def sel(self, *args, _apply_raw=True, **kwargs):

--- a/brainscore/metrics/__init__.py
+++ b/brainscore/metrics/__init__.py
@@ -1,5 +1,5 @@
 """
-a :class:`~brainscore.metrics.Metric` is part of a :class:`~brainscore.benchmarks.Benchmark`
+A :class:`~brainscore.metrics.Metric` is part of a :class:`~brainscore.benchmarks.Benchmark`
 and scores how similar two sets of data are.
 Typically these two sets are model and primate measurements, but metrics are agnostic of the data source
 and can also be used to compare two primate measurements (e.g. for ceiling estimates).

--- a/brainscore/metrics/__init__.py
+++ b/brainscore/metrics/__init__.py
@@ -1,3 +1,8 @@
+"""
+Metrics are a part of :class:`~brainscore.benchmarks.Benchmark`s and score how similar two sets of data are.
+Typically these two sets are model and primate measurements, but metrics are agnostic of the data source.
+"""
+
 import warnings
 
 import logging
@@ -10,6 +15,7 @@ class Metric:
     Metric interface.
     A metric compares two sets of data and outputs a score of how well they match (1 = identical, 0 = no match).
     """
+
     def __call__(self, assembly1, assembly2):
         """
         Compare two assemblies on their similarity.

--- a/brainscore/model_interface.py
+++ b/brainscore/model_interface.py
@@ -60,16 +60,18 @@ class BrainModel:
         corresponding recordings. These recordings are a :class:`~brainio_base.assemblies.NeuroidAssembly` with exactly
         3 dimensions:
 
-        - `presentation`: the presented stimuli (cf. stimuli argument of
-                :meth:`~brainscore.model_interface.BrainModel.look_at`). If a :class:`~brainio_base.stimuli.StimulusSet`
-                was passed, the recordings should contain all of the :class:`~brainio_base.stimuli.StimulusSet` columns
-                as coordinates on this dimension. The `image_id` coordinate is required in either case.
-        - `neuroid`: the recorded neuroids (neurons or mixtures thereof). They should all be part of the specified
-                :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this dimension should
-                again include as much information as is available, at the very least a `neuroid_id`.
-        - `time_bins`: the time bins of each recording slice. This dimension should contain at least 2 coordinates:
-                `time_bin_start` and `time_bin_end`, where one `time_bin` is the bin between start and end.
-                For instance, a 70-170ms time_bin would be marked as `time_bin_start=70` and `time_bin_end=170`.
+        - `presentation`: the presented stimuli (cf. stimuli argument
+                of :meth:`~brainscore.model_interface.BrainModel.look_at`).
+                If a :class:`~brainio_base.stimuli.StimulusSet` was passed, the recordings should contain all of
+                the :class:`~brainio_base.stimuli.StimulusSet` columns as coordinates on this dimension. The `image_id`
+                coordinate is required in either case.
+        - `neuroid`: the recorded neuroids (neurons or mixtures thereof). They should all be part of the
+                specified :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this
+                dimension should again include as much information as is available, at the very least a `neuroid_id`.
+        - `time_bins`: the time bins of each recording slice.
+                This dimension should contain at least 2 coordinates: `time_bin_start` and `time_bin_end`,
+                where one `time_bin` is the bin between start and end. For instance, a 70-170ms time_bin would be
+                marked as `time_bin_start=70` and `time_bin_end=170`.
                 If only one time_bin is requested, the model may choose to omit this dimension.
 
         :param recording_target: which location to record from

--- a/brainscore/model_interface.py
+++ b/brainscore/model_interface.py
@@ -72,6 +72,7 @@ class BrainModel:
             requested, the model may choose to omit this dimension.
 
         :param recording_target: which location to record from
-        :param time_bins: which time_bins to record
+        :param time_bins: which time_bins to record as a list of integer tuples,
+            e.g. `[(50, 100), (100, 150), (150, 200)]` or `[(70, 170)]`
         """
         raise NotImplementedError()

--- a/brainscore/model_interface.py
+++ b/brainscore/model_interface.py
@@ -60,19 +60,17 @@ class BrainModel:
         corresponding recordings. These recordings are a :class:`~brainio_base.assemblies.NeuroidAssembly` with exactly
         3 dimensions:
 
-        - `presentation`: the presented stimuli (cf. stimuli argument
-                of :meth:`~brainscore.model_interface.BrainModel.look_at`).
-                If a :class:`~brainio_base.stimuli.StimulusSet` was passed, the recordings should contain all of
-                the :class:`~brainio_base.stimuli.StimulusSet` columns as coordinates on this dimension. The `image_id`
-                coordinate is required in either case.
+        - `presentation`: the presented stimuli (cf. stimuli argument of
+            :meth:`~brainscore.model_interface.BrainModel.look_at`). If a :class:`~brainio_base.stimuli.StimulusSet`
+            was passed, the recordings should contain all of the :class:`~brainio_base.stimuli.StimulusSet` columns as
+            coordinates on this dimension. The `image_id` coordinate is required in either case.
         - `neuroid`: the recorded neuroids (neurons or mixtures thereof). They should all be part of the
-                specified :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this
-                dimension should again include as much information as is available, at the very least a `neuroid_id`.
-        - `time_bins`: the time bins of each recording slice.
-                This dimension should contain at least 2 coordinates: `time_bin_start` and `time_bin_end`,
-                where one `time_bin` is the bin between start and end. For instance, a 70-170ms time_bin would be
-                marked as `time_bin_start=70` and `time_bin_end=170`.
-                If only one time_bin is requested, the model may choose to omit this dimension.
+            specified :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this
+            dimension should again include as much information as is available, at the very least a `neuroid_id`.
+        - `time_bins`: the time bins of each recording slice. This dimension should contain at least 2 coordinates:
+            `time_bin_start` and `time_bin_end`, where one `time_bin` is the bin between start and end.
+            For instance, a 70-170ms time_bin would be marked as `time_bin_start=70` and `time_bin_end=170`.
+            If only one time_bin is requested, the model may choose to omit this dimension.
 
         :param recording_target: which location to record from
         :param time_bins: which time_bins to record as a list of integer tuples,

--- a/brainscore/model_interface.py
+++ b/brainscore/model_interface.py
@@ -61,16 +61,16 @@ class BrainModel:
         3 dimensions:
 
         - `presentation`: the presented stimuli (cf. stimuli argument of
-            :meth:`~brainscore.model_interface.BrainModel.look_at`). If a :class:`~brainio_base.stimuli.StimulusSet`
-            was passed, the recordings should contain all of the :class:`~brainio_base.stimuli.StimulusSet` columns as
-            coordinates on this dimension. The `image_id` coordinate is required in either case.
+          :meth:`~brainscore.model_interface.BrainModel.look_at`). If a :class:`~brainio_base.stimuli.StimulusSet`
+          was passed, the recordings should contain all of the :class:`~brainio_base.stimuli.StimulusSet` columns as
+          coordinates on this dimension. The `image_id` coordinate is required in either case.
         - `neuroid`: the recorded neuroids (neurons or mixtures thereof). They should all be part of the
-            specified :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this
-            dimension should again include as much information as is available, at the very least a `neuroid_id`.
+          specified :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this
+          dimension should again include as much information as is available, at the very least a `neuroid_id`.
         - `time_bins`: the time bins of each recording slice. This dimension should contain at least 2 coordinates:
-            `time_bin_start` and `time_bin_end`, where one `time_bin` is the bin between start and end.
-            For instance, a 70-170ms time_bin would be marked as `time_bin_start=70` and `time_bin_end=170`.
-            If only one time_bin is requested, the model may choose to omit this dimension.
+          `time_bin_start` and `time_bin_end`, where one `time_bin` is the bin between start and end.
+          For instance, a 70-170ms time_bin would be marked as `time_bin_start=70` and `time_bin_end=170`.
+          If only one time_bin is requested, the model may choose to omit this dimension.
 
         :param recording_target: which location to record from
         :param time_bins: which time_bins to record as a list of integer tuples,

--- a/brainscore/model_interface.py
+++ b/brainscore/model_interface.py
@@ -33,7 +33,7 @@ class BrainModel:
         """
         Digest a set of stimuli and return requested outputs. Which outputs to return is instructed by the
         :meth:`~brainscore.model_interface.BrainMode.start_task` and
-        :meth:`brainscore.model_interface.BrainModel.start_recording` methods.
+        :meth:`~brainscore.model_interface.BrainModel.start_recording` methods.
 
         :param stimuli: A set of stimuli, passed as either a :class:`~brainio_base.stimuli.StimulusSet`
             or a list of image file paths
@@ -59,17 +59,18 @@ class BrainModel:
         For all followings call of :meth:`~brainscore.model_interface.BrainModel.look_at`, the model returns the
         corresponding recordings. These recordings are a :class:`~brainio_base.assemblies.NeuroidAssembly` with exactly
         3 dimensions:
+
         - `presentation`: the presented stimuli (cf. stimuli argument of
-            :meth:`~brainscore.model_interface.BrainModel.look_at`). If a :class:`~brainio_base.stimuli.StimulusSet`
-            was passed, the recordings should contain all of the :class:`~brainio_base.stimuli.StimulusSet` columns as
-            coordinates on this dimension. The `image_id` coordinate is required in either case.
+                :meth:`~brainscore.model_interface.BrainModel.look_at`). If a :class:`~brainio_base.stimuli.StimulusSet`
+                was passed, the recordings should contain all of the :class:`~brainio_base.stimuli.StimulusSet` columns
+                as coordinates on this dimension. The `image_id` coordinate is required in either case.
         - `neuroid`: the recorded neuroids (neurons or mixtures thereof). They should all be part of the specified
-            :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this dimension should
-            again include as much information as is available, at the very least a `neuroid_id`.
+                :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this dimension should
+                again include as much information as is available, at the very least a `neuroid_id`.
         - `time_bins`: the time bins of each recording slice. This dimension should contain at least 2 coordinates:
-            `time_bin_start` and `time_bin_end`, where one `time_bin` is the bin between start and end. For instance, a
-            70-170ms time_bin would be marked as `time_bin_start=70` and `time_bin_end=170`. If only one time_bin is
-            requested, the model may choose to omit this dimension.
+                `time_bin_start` and `time_bin_end`, where one `time_bin` is the bin between start and end.
+                For instance, a 70-170ms time_bin would be marked as `time_bin_start=70` and `time_bin_end=170`.
+                If only one time_bin is requested, the model may choose to omit this dimension.
 
         :param recording_target: which location to record from
         :param time_bins: which time_bins to record as a list of integer tuples,

--- a/brainscore/model_interface.py
+++ b/brainscore/model_interface.py
@@ -1,23 +1,77 @@
 from enum import Enum
-from typing import List, Tuple
+
+from brainio_base.stimuli import StimulusSet
+from typing import List, Tuple, Union
 
 
 class BrainModel:
+    """
+    The BrainModel interface defines an API for models to follow.
+    Benchmarks will use this interface to treat models as an experimental subject
+    without needing to know about the details of the model implementation.
+    """
+
     RecordingTarget = Enum('RecordingTarget', " ".join(['V1', 'V2', 'V4', 'IT']))
+    """
+    location to record from
+    """
+
     Task = Enum('Task', " ".join(['passive', 'probabilities', 'label']))
-    
+    """
+    task to perform
+    """
+
     def visual_degrees(self) -> int:
         """
         The visual degrees this model covers as a single scalar.
+
         :return: e.g. `8`, or `10`
         """
         raise NotImplementedError()
 
-    def look_at(self, stimuli):
+    def look_at(self, stimuli: Union[StimulusSet, List[str]]):
+        """
+        Digest a set of stimuli and return requested outputs. Which outputs to return is instructed by the
+        :meth:`~brainscore.model_interface.BrainMode.start_task` and
+        :meth:`brainscore.model_interface.BrainModel.start_recording` methods.
+
+        :param stimuli: A set of stimuli, passed as either a :class:`~brainio_base.stimuli.StimulusSet`
+            or a list of image file paths
+        :return: recordings or task behaviors as instructed
+        """
         raise NotImplementedError()
 
     def start_task(self, task: Task, fitting_stimuli):
+        """
+        Instructs the model to begin one of the tasks specified in :data:`~brainscore.model_interface.BrainModel.Task`.
+        For all followings call of :meth:`~brainscore.model_interface.BrainModel.look_at`, the model returns the
+        expected outputs for the specified task.
+
+        :param task: The task the model should perform, and thus which outputs it should return
+        :param fitting_stimuli: A set of stimuli for the model to learn on, e.g. image-label pairs
+        """
         raise NotImplementedError()
 
     def start_recording(self, recording_target: RecordingTarget, time_bins=List[Tuple[int]]):
+        """
+        Instructs the model to begin recording in a specified
+        :data:`~brainscore.model_interface.BrainModel.RecordingTarget` and return the specified `time_bins`.
+        For all followings call of :meth:`~brainscore.model_interface.BrainModel.look_at`, the model returns the
+        corresponding recordings. These recordings are a :class:`~brainio_base.assemblies.NeuroidAssembly` with exactly
+        3 dimensions:
+        - `presentation`: the presented stimuli (cf. stimuli argument of
+            :meth:`~brainscore.model_interface.BrainModel.look_at`). If a :class:`~brainio_base.stimuli.StimulusSet`
+            was passed, the recordings should contain all of the :class:`~brainio_base.stimuli.StimulusSet` columns as
+            coordinates on this dimension. The `image_id` coordinate is required in either case.
+        - `neuroid`: the recorded neuroids (neurons or mixtures thereof). They should all be part of the specified
+            :data:`~brainscore.model_interface.BrainModel.RecordingTarget`. The coordinates of this dimension should
+            again include as much information as is available, at the very least a `neuroid_id`.
+        - `time_bins`: the time bins of each recording slice. This dimension should contain at least 2 coordinates:
+            `time_bin_start` and `time_bin_end`, where one `time_bin` is the bin between start and end. For instance, a
+            70-170ms time_bin would be marked as `time_bin_start=70` and `time_bin_end=170`. If only one time_bin is
+            requested, the model may choose to omit this dimension.
+
+        :param recording_target: which location to record from
+        :param time_bins: which time_bins to record
+        """
         raise NotImplementedError()

--- a/brainscore/utils/__init__.py
+++ b/brainscore/utils/__init__.py
@@ -1,7 +1,12 @@
+"""
+Provide generic helper classes.
+"""
+
 import copy
 
 
 def fullname(obj):
+    """ Resolve the full module-qualified name of an object. Typically used for logger naming. """
     return obj.__module__ + "." + obj.__class__.__name__
 
 

--- a/docs/source/modules/benchmarks.rst
+++ b/docs/source/modules/benchmarks.rst
@@ -3,12 +3,6 @@
 Benchmarks
 ----------
 
-A ``Benchmark`` runs an experiment on a model_ and tests the resulting measurements against primate data_.
-This comparison is done by :ref:`metrics` which output a score of how well model and data match.
-This score is normalized with data ceilings and the benchmark returns this ceiled score.
-
 .. automodule:: brainscore.benchmarks
     :members:
     :undoc-members:
-.. _model: https://github.com/brain-score/brain-score/blob/master/brainscore/model_interface.py
-.. _data: https://github.com/brain-score/brainio_collection

--- a/docs/source/modules/metrics.rst
+++ b/docs/source/modules/metrics.rst
@@ -3,9 +3,6 @@
 Metrics
 -------
 
-Metrics are a part of :ref:`benchmarks` and score how similar two sets of data are.
-Typically these two sets are model and primate measurements, but metrics are agnostic of the data source.
-
 .. automodule:: brainscore.metrics
     :members:
     :undoc-members:

--- a/docs/source/modules/model_interface.rst
+++ b/docs/source/modules/model_interface.rst
@@ -1,10 +1,6 @@
 BrainModel interface
 --------------------
 
-The ``BrainModel`` interface defines an API for models to follow.
-:ref:`benchmarks` will use this interface to treat models as an experimental subject
-without needing to know about the details of the model implementation.
-
 .. autoclass:: brainscore.model_interface.BrainModel
     :members:
     :undoc-members:

--- a/docs/source/modules/utils.rst
+++ b/docs/source/modules/utils.rst
@@ -1,8 +1,6 @@
 Utils
 -----
 
-The ``utils`` package provides helper classes.
-
 .. automodule:: brainscore.utils
     :members:
     :undoc-members:


### PR DESCRIPTION
Currently, a lot of documentation comments are located in readthedocs files -- this PR moves them into packages and classes themselves. This seems more useful for someone reading the code and we don't lose anything on RTD since those comments are still displayed.
I also added some more documentation on the `BrainModel`.