### PR TITLE
increase numpy version to fix RDM's nan_to_num from #216

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('README.md') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    "numpy>=1.16",
+    "numpy>=1.17",
     "brainio_base @ git+https://github.com/brain-score/brainio_base",
     "brainio_collection @ git+https://github.com/brain-score/brainio_collection",
     "scikit-learn",


### PR DESCRIPTION
"nan_to_num() got an unexpected keyword argument 'nan'"
need at least numpy 1.17 https://stackoverflow.com/a/59689390/2225200