### PR TITLE
implement looking at multiple trials to enable stochastic models

### DIFF
--- a/brainscore/benchmarks/_neural_common.py
+++ b/brainscore/benchmarks/_neural_common.py
@@ -3,12 +3,12 @@ import numpy as np
 from brainio_base.assemblies import array_is_element, walk_coords
 from brainscore.benchmarks import BenchmarkBase, ceil_score
 from brainscore.benchmarks.screen import place_on_screen
-from brainscore.benchmarks.trials import infer_trials_from_parameter_or_assembly, repeat_trials, average_trials
+from brainscore.benchmarks.trials import repeat_trials, average_trials
 from brainscore.model_interface import BrainModel
 
 
 class NeuralBenchmark(BenchmarkBase):
-    def __init__(self, identifier, assembly, similarity_metric, visual_degrees, number_of_trials=None, **kwargs):
+    def __init__(self, identifier, assembly, similarity_metric, visual_degrees, number_of_trials, **kwargs):
         super(NeuralBenchmark, self).__init__(identifier=identifier, **kwargs)
         self._assembly = assembly
         self._similarity_metric = similarity_metric
@@ -18,7 +18,7 @@ class NeuralBenchmark(BenchmarkBase):
         timebins = timebins_from_assembly(self._assembly)
         self.timebins = timebins
         self._visual_degrees = visual_degrees
-        self._number_of_trials = infer_trials_from_parameter_or_assembly(number_of_trials, assembly)
+        self._number_of_trials = number_of_trials
 
     def __call__(self, candidate: BrainModel):
         candidate.start_recording(self.region, time_bins=self.timebins)

--- a/brainscore/benchmarks/_neural_common.py
+++ b/brainscore/benchmarks/_neural_common.py
@@ -3,11 +3,12 @@ import numpy as np
 from brainio_base.assemblies import array_is_element, walk_coords
 from brainscore.benchmarks import BenchmarkBase, ceil_score
 from brainscore.benchmarks.screen import place_on_screen
+from brainscore.benchmarks.trials import infer_trials_from_parameter_or_assembly, repeat_trials, average_trials
 from brainscore.model_interface import BrainModel
 
 
 class NeuralBenchmark(BenchmarkBase):
-    def __init__(self, identifier, assembly, similarity_metric, visual_degrees, **kwargs):
+    def __init__(self, identifier, assembly, similarity_metric, visual_degrees, number_of_trials=None, **kwargs):
         super(NeuralBenchmark, self).__init__(identifier=identifier, **kwargs)
         self._assembly = assembly
         self._similarity_metric = similarity_metric
@@ -17,14 +18,17 @@ class NeuralBenchmark(BenchmarkBase):
         timebins = timebins_from_assembly(self._assembly)
         self.timebins = timebins
         self._visual_degrees = visual_degrees
+        self._number_of_trials = infer_trials_from_parameter_or_assembly(number_of_trials, assembly)
 
     def __call__(self, candidate: BrainModel):
         candidate.start_recording(self.region, time_bins=self.timebins)
         stimulus_set = place_on_screen(self._assembly.stimulus_set, target_visual_degrees=candidate.visual_degrees(),
                                        source_visual_degrees=self._visual_degrees)
+        stimulus_set = repeat_trials(stimulus_set, number_of_trials=self._number_of_trials)
         source_assembly = candidate.look_at(stimulus_set)
         if 'time_bin' in source_assembly.dims:
             source_assembly = source_assembly.squeeze('time_bin')  # static case for these benchmarks
+        source_assembly = average_trials(source_assembly)
         raw_score = self._similarity_metric(source_assembly, self._assembly)
         return explained_variance(raw_score, self.ceiling)
 

--- a/brainscore/benchmarks/cadena2017.py
+++ b/brainscore/benchmarks/cadena2017.py
@@ -33,7 +33,8 @@ def ToliasCadena2017PLS():
         return ceiler(assembly_nonan)
 
     return NeuralBenchmark(identifier=identifier, version=1,
-                           assembly=assembly, similarity_metric=similarity_metric, visual_degrees=VISUAL_DEGREES,
+                           assembly=assembly, similarity_metric=similarity_metric,
+                           visual_degrees=VISUAL_DEGREES, number_of_trials=2,
                            ceiling_func=ceiling)
 
 

--- a/brainscore/benchmarks/freemanziemba2013.py
+++ b/brainscore/benchmarks/freemanziemba2013.py
@@ -8,15 +8,16 @@ from brainscore.utils import LazyLoad
 from result_caching import store
 
 VISUAL_DEGREES = 4
+NUMBER_OF_TRIALS = 20
 
 
 def _MovshonFreemanZiemba2013Region(region, identifier_metric_suffix, similarity_metric, ceiler):
     assembly_repetition = LazyLoad(lambda region=region: load_assembly(False, region=region))
     assembly = LazyLoad(lambda region=region: load_assembly(True, region=region))
     return NeuralBenchmark(identifier=f'movshon.FreemanZiemba2013.{region}-{identifier_metric_suffix}', version=2,
-                           assembly=assembly, similarity_metric=similarity_metric, visual_degrees=VISUAL_DEGREES,
+                           assembly=assembly, similarity_metric=similarity_metric, parent=region,
                            ceiling_func=lambda: ceiler(assembly_repetition),
-                           parent=region,
+                           visual_degrees=VISUAL_DEGREES, number_of_trials=NUMBER_OF_TRIALS,
                            paper_link='https://www.nature.com/articles/nn.3402')
 
 

--- a/brainscore/benchmarks/imagenet.py
+++ b/brainscore/benchmarks/imagenet.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from brainio_base.stimuli import StimulusSet
 from brainscore.benchmarks import BenchmarkBase
+from brainscore.benchmarks.trials import repeat_trials, average_trials
 from brainscore.metrics import Score
 from brainscore.metrics.accuracy import Accuracy
 from brainscore.model_interface import BrainModel
@@ -24,10 +25,13 @@ class Imagenet2012(BenchmarkBase):
                                            paper_link="https://ieeexplore.ieee.org/abstract/document/5206848")
 
     def __call__(self, candidate):
-        # the proper `fitting_stimuli` to pass to the candidate would be the imagenet training set.
-        # for now, since all models in our hands were trained with imagenet, we'll just short-cut this
+        # The proper `fitting_stimuli` to pass to the candidate would be the imagenet training set.
+        # For now, since almost all models in our hands were trained with imagenet, we'll just short-cut this
         # by telling the candidate to use its pre-trained imagenet weights.
         candidate.start_task(BrainModel.Task.label, 'imagenet')
-        predictions = candidate.look_at(self._stimulus_set[list(set(self._stimulus_set.columns) - {'synset'})])
+        stimulus_set = self._stimulus_set[list(set(self._stimulus_set.columns) - {'synset'})]  # do not show label
+        stimulus_set = repeat_trials(stimulus_set, number_of_trials=10)
+        predictions = candidate.look_at(stimulus_set)
+        predictions = average_trials(predictions)
         score = self._similarity_metric(predictions, self._stimulus_set['synset'].values)
         return score

--- a/brainscore/benchmarks/majajhong2015.py
+++ b/brainscore/benchmarks/majajhong2015.py
@@ -13,7 +13,8 @@ def _DicarloMajajHong2015Region(region, identifier_metric_suffix, similarity_met
     assembly_repetition = LazyLoad(lambda region=region: load_assembly(average_repetitions=False, region=region))
     assembly = LazyLoad(lambda region=region: load_assembly(average_repetitions=True, region=region))
     return NeuralBenchmark(identifier=f'dicarlo.MajajHong2015.{region}-{identifier_metric_suffix}', version=3,
-                           assembly=assembly, similarity_metric=similarity_metric, visual_degrees=VISUAL_DEGREES,
+                           assembly=assembly, similarity_metric=similarity_metric,
+                           visual_degrees=VISUAL_DEGREES, number_of_trials=50,
                            ceiling_func=lambda: ceiler(assembly_repetition),
                            parent=region, paper_link='http://www.jneurosci.org/content/35/39/13402.short')
 

--- a/brainscore/benchmarks/majajhong2015.py
+++ b/brainscore/benchmarks/majajhong2015.py
@@ -7,6 +7,7 @@ from brainscore.metrics.regression import CrossRegressedCorrelation, mask_regres
 from brainscore.utils import LazyLoad
 
 VISUAL_DEGREES = 8
+NUMBER_OF_TRIALS = 50
 
 
 def _DicarloMajajHong2015Region(region, identifier_metric_suffix, similarity_metric, ceiler):
@@ -14,7 +15,7 @@ def _DicarloMajajHong2015Region(region, identifier_metric_suffix, similarity_met
     assembly = LazyLoad(lambda region=region: load_assembly(average_repetitions=True, region=region))
     return NeuralBenchmark(identifier=f'dicarlo.MajajHong2015.{region}-{identifier_metric_suffix}', version=3,
                            assembly=assembly, similarity_metric=similarity_metric,
-                           visual_degrees=VISUAL_DEGREES, number_of_trials=50,
+                           visual_degrees=VISUAL_DEGREES, number_of_trials=NUMBER_OF_TRIALS,
                            ceiling_func=lambda: ceiler(assembly_repetition),
                            parent=region, paper_link='http://www.jneurosci.org/content/35/39/13402.short')
 

--- a/brainscore/benchmarks/public_benchmarks.py
+++ b/brainscore/benchmarks/public_benchmarks.py
@@ -20,14 +20,16 @@ from brainscore.benchmarks._neural_common import NeuralBenchmark
 from brainscore.metrics.ceiling import InternalConsistency
 from brainscore.metrics.regression import CrossRegressedCorrelation, pls_regression, pearsonr_correlation
 from brainscore.utils import LazyLoad
-from .freemanziemba2013 import load_assembly as load_freemanziemba2013, VISUAL_DEGREES as freemanziemba2013_degrees
-from .majajhong2015 import load_assembly as load_majajhong2015, VISUAL_DEGREES as majajhong2015_degrees
+from .freemanziemba2013 import load_assembly as load_freemanziemba2013, VISUAL_DEGREES as freemanziemba2013_degrees, \
+    NUMBER_OF_TRIALS as freemanziemba2013_trials
+from .majajhong2015 import load_assembly as load_majajhong2015, VISUAL_DEGREES as majajhong2015_degrees, \
+    NUMBER_OF_TRIALS as majajhong2015_trials
 from .rajalingham2018 import load_assembly as load_rajalingham2018, DicarloRajalingham2018I2n
 
 _logger = logging.getLogger(__name__)
 
 
-def _standard_benchmark(identifier, load_assembly, visual_degrees, stratification_coord):
+def _standard_benchmark(identifier, load_assembly, visual_degrees, number_of_trials, stratification_coord):
     assembly_repetition = LazyLoad(lambda: load_assembly(average_repetitions=False))
     assembly = LazyLoad(lambda: load_assembly(average_repetitions=True))
     similarity_metric = CrossRegressedCorrelation(
@@ -35,7 +37,8 @@ def _standard_benchmark(identifier, load_assembly, visual_degrees, stratificatio
         crossvalidation_kwargs=dict(stratification_coord=stratification_coord))
     ceiler = InternalConsistency()
     return NeuralBenchmark(identifier=f"{identifier}-pls", version=1,
-                           assembly=assembly, similarity_metric=similarity_metric, visual_degrees=visual_degrees,
+                           assembly=assembly, similarity_metric=similarity_metric,
+                           visual_degrees=visual_degrees, number_of_trials=number_of_trials,
                            ceiling_func=lambda: ceiler(assembly_repetition),
                            parent=None, paper_link='http://www.jneurosci.org/content/35/39/13402.short')
 
@@ -43,25 +46,29 @@ def _standard_benchmark(identifier, load_assembly, visual_degrees, stratificatio
 def FreemanZiembaV1PublicBenchmark():
     return _standard_benchmark('movshon.FreemanZiemba2013.V1.public',
                                load_assembly=functools.partial(load_freemanziemba2013, region='V1', access='public'),
-                               visual_degrees=freemanziemba2013_degrees, stratification_coord='texture_type')
+                               visual_degrees=freemanziemba2013_degrees, number_of_trials=freemanziemba2013_trials,
+                               stratification_coord='texture_type')
 
 
 def FreemanZiembaV2PublicBenchmark():
     return _standard_benchmark('movshon.FreemanZiemba2013.V2.public',
                                load_assembly=functools.partial(load_freemanziemba2013, region='V2', access='public'),
-                               visual_degrees=freemanziemba2013_degrees, stratification_coord='texture_type')
+                               visual_degrees=freemanziemba2013_degrees, number_of_trials=freemanziemba2013_trials,
+                               stratification_coord='texture_type')
 
 
 def MajajHongV4PublicBenchmark():
     return _standard_benchmark('dicarlo.MajajHong2015.V4.public',
                                load_assembly=functools.partial(load_majajhong2015, region='V4', access='public'),
-                               visual_degrees=majajhong2015_degrees, stratification_coord='object_name')
+                               visual_degrees=majajhong2015_degrees, number_of_trials=majajhong2015_trials,
+                               stratification_coord='object_name')
 
 
 def MajajHongITPublicBenchmark():
     return _standard_benchmark('dicarlo.MajajHong2015.IT.public',
                                load_assembly=functools.partial(load_majajhong2015, region='IT', access='public'),
-                               visual_degrees=majajhong2015_degrees, stratification_coord='object_name')
+                               visual_degrees=majajhong2015_degrees, number_of_trials=majajhong2015_trials,
+                               stratification_coord='object_name')
 
 
 class RajalinghamMatchtosamplePublicBenchmark(DicarloRajalingham2018I2n):

--- a/brainscore/benchmarks/trials.py
+++ b/brainscore/benchmarks/trials.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 import pandas as pd
 
-from brainio_base.assemblies import walk_coords
+from brainio_base.assemblies import walk_coords, array_is_element
 
 
 def repeat_trials(stimulus_set, number_of_trials):
@@ -29,7 +29,7 @@ def repeat_trials(stimulus_set, number_of_trials):
 
 def average_trials(assembly):
     non_repetition_coords = [coord for coord, dim, values in walk_coords(assembly['presentation'])
-                             if coord != 'repetition']
+                             if array_is_element(dim, 'presentation') and coord != 'repetition']
     grouped = assembly.multi_groupby(non_repetition_coords)
     if np.issubdtype(assembly.dtype, np.number):
         return grouped.mean('presentation')

--- a/brainscore/benchmarks/trials.py
+++ b/brainscore/benchmarks/trials.py
@@ -1,6 +1,6 @@
 import copy
-from collections import defaultdict
 
+import numpy as np
 import pandas as pd
 
 from brainio_base.assemblies import walk_coords
@@ -12,24 +12,26 @@ def repeat_trials(stimulus_set, number_of_trials):
     meta = {meta_key: copy.deepcopy(getattr(stimulus_set, meta_key)) for meta_key in stimulus_set._metadata
             if not callable(getattr(stimulus_set, meta_key))}  # don't copy functions
     # repeat stimulus set
+    num_stimuli = len(stimulus_set)
     assert isinstance(number_of_trials, int)
     stimulus_set = pd.concat([stimulus_set] * number_of_trials)
-    repetitions, repetition_counter = [], defaultdict(lambda: 0)
-    for _, row in stimulus_set.iterrows():
-        repetitions.append(repetition_counter[row['image_id']])
-        repetition_counter[row['image_id']] += 1
-    stimulus_set['repetition'] = repetitions
+    stimulus_set['repetition'] = list(range(number_of_trials)) * num_stimuli
     # re-attach meta
     for meta_key, meta_value in meta.items():
         setattr(stimulus_set, meta_key, meta_value)
     # we use a different identifier from the original identifier here so stochastic model will produce different
     # activations for different trials. Non-stochastic model might have to be run multiple times but in practice the
     # same stimulus set usually has the same number of trials.
-    stimulus_set.identifier = stimulus_set.identifier + f'-{number_of_trials}trials'
+    if hasattr(stimulus_set, 'identifier') and stimulus_set.identifier is not None:
+        stimulus_set.identifier = stimulus_set.identifier + f'-{number_of_trials}trials'
     return stimulus_set
 
 
 def average_trials(assembly):
     non_repetition_coords = [coord for coord, dim, values in walk_coords(assembly['presentation'])
                              if coord != 'repetition']
-    return assembly.multi_groupby(non_repetition_coords).mean('presentation')
+    grouped = assembly.multi_groupby(non_repetition_coords)
+    if np.issubdtype(assembly.dtype, np.number):
+        return grouped.mean('presentation')
+    else:  # for non-numbers take majority
+        return grouped.max('presentation')

--- a/brainscore/benchmarks/trials.py
+++ b/brainscore/benchmarks/trials.py
@@ -10,7 +10,8 @@ def repeat_trials(stimulus_set, number_of_trials):
     # maintain metadata
     assert not hasattr(stimulus_set, 'repetition')
     meta = {meta_key: copy.deepcopy(getattr(stimulus_set, meta_key)) for meta_key in stimulus_set._metadata
-            if not callable(getattr(stimulus_set, meta_key))}  # don't copy functions
+            if hasattr(stimulus_set, meta_key)  # e.g. identifier might not be set
+            and not callable(getattr(stimulus_set, meta_key))}  # don't copy functions
     # repeat stimulus set
     num_stimuli = len(stimulus_set)
     assert isinstance(number_of_trials, int)

--- a/brainscore/benchmarks/trials.py
+++ b/brainscore/benchmarks/trials.py
@@ -1,0 +1,45 @@
+import copy
+from collections import defaultdict
+
+import pandas as pd
+
+
+def infer_trials_from_parameter_or_assembly(number_of_trials, assembly):
+    if number_of_trials is None:
+        assert hasattr(assembly, 'repetitions'), "number_of_trials parameter not specified " \
+                                                "and assembly['repetitions'] missing"
+        return {row.image_id: len(row.repetition) for row in assembly.groupby('image_id')}
+    else:
+        assert not hasattr(assembly, 'repetitions'), "number_of_trials can be specified through " \
+                                                    "either the parameter or assembly['repetitions'], but not both"
+        return number_of_trials
+
+
+def repeat_trials(stimulus_set, number_of_trials):
+    assert not hasattr(stimulus_set, 'repetition')
+    meta = {meta_key: copy.deepcopy(getattr(stimulus_set, meta_key)) for meta_key in stimulus_set._metadata
+            if not callable(getattr(stimulus_set, meta_key))}  # don't copy functions
+    # number_of_trials can either be an integer or some per-image assignment
+    if isinstance(number_of_trials, int):
+        identifier_suffix = f"{number_of_trials}"
+        stimulus_set = pd.concat([stimulus_set] * number_of_trials)
+        repetitions, repetition_counter = [], defaultdict(lambda: 0)
+        for _, row in stimulus_set.iterrows():
+            repetitions.append(repetition_counter[row['image_id']])
+            repetition_counter[row['image_id']] += 1
+        stimulus_set['repetition'] = repetitions
+    else:
+        identifier_suffix = hash(number_of_trials)
+        raise NotImplementedError()
+
+    for meta_key, meta_value in meta.items():
+        setattr(stimulus_set, meta_key, meta_value)
+    # we use different identifiers here so stochastic model will produce different activations for different trials.
+    # Non-stochastic model might have to be run multiple times but in practice the same stimulus set usually has the
+    # same number of trials
+    stimulus_set.identifier = stimulus_set.identifier + f'-{identifier_suffix}trials'
+    return stimulus_set
+
+
+def average_trials(assembly):
+    return assembly.mean('repetition')

--- a/brainscore/benchmarks/trials.py
+++ b/brainscore/benchmarks/trials.py
@@ -3,43 +3,33 @@ from collections import defaultdict
 
 import pandas as pd
 
-
-def infer_trials_from_parameter_or_assembly(number_of_trials, assembly):
-    if number_of_trials is None:
-        assert hasattr(assembly, 'repetitions'), "number_of_trials parameter not specified " \
-                                                "and assembly['repetitions'] missing"
-        return {row.image_id: len(row.repetition) for row in assembly.groupby('image_id')}
-    else:
-        assert not hasattr(assembly, 'repetitions'), "number_of_trials can be specified through " \
-                                                    "either the parameter or assembly['repetitions'], but not both"
-        return number_of_trials
+from brainio_base.assemblies import walk_coords
 
 
 def repeat_trials(stimulus_set, number_of_trials):
+    # maintain metadata
     assert not hasattr(stimulus_set, 'repetition')
     meta = {meta_key: copy.deepcopy(getattr(stimulus_set, meta_key)) for meta_key in stimulus_set._metadata
             if not callable(getattr(stimulus_set, meta_key))}  # don't copy functions
-    # number_of_trials can either be an integer or some per-image assignment
-    if isinstance(number_of_trials, int):
-        identifier_suffix = f"{number_of_trials}"
-        stimulus_set = pd.concat([stimulus_set] * number_of_trials)
-        repetitions, repetition_counter = [], defaultdict(lambda: 0)
-        for _, row in stimulus_set.iterrows():
-            repetitions.append(repetition_counter[row['image_id']])
-            repetition_counter[row['image_id']] += 1
-        stimulus_set['repetition'] = repetitions
-    else:
-        identifier_suffix = hash(number_of_trials)
-        raise NotImplementedError()
-
+    # repeat stimulus set
+    assert isinstance(number_of_trials, int)
+    stimulus_set = pd.concat([stimulus_set] * number_of_trials)
+    repetitions, repetition_counter = [], defaultdict(lambda: 0)
+    for _, row in stimulus_set.iterrows():
+        repetitions.append(repetition_counter[row['image_id']])
+        repetition_counter[row['image_id']] += 1
+    stimulus_set['repetition'] = repetitions
+    # re-attach meta
     for meta_key, meta_value in meta.items():
         setattr(stimulus_set, meta_key, meta_value)
-    # we use different identifiers here so stochastic model will produce different activations for different trials.
-    # Non-stochastic model might have to be run multiple times but in practice the same stimulus set usually has the
-    # same number of trials
-    stimulus_set.identifier = stimulus_set.identifier + f'-{identifier_suffix}trials'
+    # we use a different identifier from the original identifier here so stochastic model will produce different
+    # activations for different trials. Non-stochastic model might have to be run multiple times but in practice the
+    # same stimulus set usually has the same number of trials.
+    stimulus_set.identifier = stimulus_set.identifier + f'-{number_of_trials}trials'
     return stimulus_set
 
 
 def average_trials(assembly):
-    return assembly.mean('repetition')
+    non_repetition_coords = [coord for coord, dim, values in walk_coords(assembly['presentation'])
+                             if coord != 'repetition']
+    return assembly.multi_groupby(non_repetition_coords).mean('presentation')

--- a/tests/test_benchmarks/test___init__.py
+++ b/tests/test_benchmarks/test___init__.py
@@ -267,6 +267,7 @@ class TestVisualDegrees:
 
 
 class TestNumberOfTrials:
+    @pytest.mark.private_access
     @pytest.mark.parametrize('benchmark_identifier', evaluation_benchmark_pool.keys())
     def test_repetitions(self, benchmark_identifier):
         """ Tests that all evaluation benchmarks have repetitions in the stimulus_set """

--- a/tests/test_benchmarks/test___init__.py
+++ b/tests/test_benchmarks/test___init__.py
@@ -266,6 +266,37 @@ class TestVisualDegrees:
             pass
 
 
+class TestNumberOfTrials:
+    @pytest.mark.parametrize('benchmark_identifier', evaluation_benchmark_pool.keys())
+    def test_repetitions(self, benchmark_identifier):
+        """ Tests that all evaluation benchmarks have repetitions in the stimulus_set """
+        benchmark = benchmark_pool[benchmark_identifier]
+
+        class AssertRepeatCandidate(BrainModel):
+            class StopException(Exception):
+                pass
+
+            def visual_degrees(self):
+                return 8
+
+            def look_at(self, stimuli):
+                unique_images = set(stimuli.get_image(image_id) for image_id in stimuli['image_id'])
+                assert len(unique_images) < len(stimuli)
+                raise self.StopException()
+
+            def start_task(self, task: BrainModel.Task, fitting_stimuli):
+                pass
+
+            def start_recording(self, recording_target: BrainModel.RecordingTarget, time_bins=List[Tuple[int]]):
+                pass
+
+        candidate = AssertRepeatCandidate()
+        try:
+            benchmark(candidate)  # just call to get the stimuli
+        except AssertRepeatCandidate.StopException:  # but stop early
+            pass
+
+
 def lstrip_local(path):
     parts = path.split(os.sep)
     brainio_index = parts.index('.brainio')

--- a/tests/test_benchmarks/test_imagenet.py
+++ b/tests/test_benchmarks/test_imagenet.py
@@ -1,5 +1,7 @@
+import numpy as np
 from pytest import approx
 
+from brainio_base.assemblies import BehavioralAssembly
 from brainscore.benchmarks.imagenet import Imagenet2012
 from brainscore.model_interface import BrainModel
 
@@ -15,8 +17,15 @@ class TestImagenet2012:
                 assert fitting_stimuli == 'imagenet'  # shortcut
 
             def look_at(self, stimuli):
-                aligned_source = source[source['image_id'] == stimuli['image_id']]
-                return aligned_source['synset'].values
+                source_image_ids = source['image_id'].values
+                stimuli_image_ids = stimuli['image_id'].values
+                sorted_x = source_image_ids[np.argsort(source_image_ids)]
+                sorted_index = np.searchsorted(sorted_x, stimuli_image_ids)
+                aligned_source = source.loc[sorted_index]
+                labels = aligned_source['synset'].values
+                return BehavioralAssembly([labels], coords={
+                    **{column: ('presentation', aligned_source[column].values) for column in aligned_source.columns},
+                    **{'choice': ('choice', ['dummy'])}}, dims=['choice', 'presentation'])
 
         candidate = GroundTruth()
         score = benchmark(candidate)

--- a/tests/test_benchmarks/test_trials.py
+++ b/tests/test_benchmarks/test_trials.py
@@ -1,0 +1,37 @@
+from brainio_base.stimuli import StimulusSet
+from brainscore.benchmarks.trials import repeat_trials
+
+
+def _dummy_stimulus_set():
+    stimulus_set = StimulusSet([
+        {'image_id': 'a'},
+        {'image_id': 'b'},
+        {'image_id': 'c'},
+    ])
+    stimulus_set.image_paths = {
+        'a': 'a.png',
+        'b': 'b.png',
+        'c': 'c.png',
+    }
+    stimulus_set.identifier = 'dummy'
+    return stimulus_set
+
+
+def test_integer_repeat():
+    stimulus_set = _dummy_stimulus_set()
+    repeat_stimulus_set = repeat_trials(stimulus_set, number_of_trials=5)
+    assert len(repeat_stimulus_set) == len(stimulus_set) * 5
+    original_image_paths = [stimulus_set.get_image(image_id) for image_id in stimulus_set['image_id']]
+    repeat_image_paths = [repeat_stimulus_set.get_image(image_id) for image_id in repeat_stimulus_set['image_id']]
+    assert set(repeat_image_paths) == set(original_image_paths)
+    assert all(len(group) == 5 and set(group['repetition']) == {0, 1, 2, 3, 4}
+               for name, group in repeat_stimulus_set.groupby('image_id'))
+    assert repeat_stimulus_set.identifier == 'dummy-5trials'
+
+
+def test_per_image_repeat():
+    pass
+
+
+def test_average_trials():
+    pass

--- a/tests/test_benchmarks/test_trials.py
+++ b/tests/test_benchmarks/test_trials.py
@@ -1,5 +1,8 @@
+import numpy as np
+
+from brainio_base.assemblies import NeuroidAssembly
 from brainio_base.stimuli import StimulusSet
-from brainscore.benchmarks.trials import repeat_trials
+from brainscore.benchmarks.trials import repeat_trials, average_trials
 
 
 def _dummy_stimulus_set():
@@ -29,9 +32,27 @@ def test_integer_repeat():
     assert repeat_stimulus_set.identifier == 'dummy-5trials'
 
 
-def test_per_image_repeat():
-    pass
-
-
 def test_average_trials():
-    pass
+    assembly = NeuroidAssembly([[1, 2, 3],
+                                [2, 3, 4],
+                                [3, 4, 5],
+                                [4, 5, 6],
+                                [5, 6, 7],
+                                [6, 7, 8],
+                                [7, 8, 9],
+                                [8, 9, 10]],
+                               coords={'image_id': ('presentation', ['a', 'a', 'b', 'b', 'c', 'c', 'd', 'd']),
+                                       'repetition': ('presentation', [0, 1, 0, 1, 0, 1, 0, 1]),
+                                       'presentation_dummy': ('presentation', ['x'] * 8),
+                                       'neuroid_id': ('neuroid', [0, 1, 2]),
+                                       'region': ('neuroid', ['IT', 'IT', 'IT'])},
+                               dims=['presentation', 'neuroid'])
+    averaged_assembly = average_trials(assembly)
+    assert len(averaged_assembly['neuroid']) == 3, "messed up neuroids"
+    assert len(averaged_assembly['presentation']) == 4
+    assert set(averaged_assembly['image_id'].values) == {'a', 'b', 'c', 'd'}
+    np.testing.assert_array_equal(averaged_assembly['neuroid_id'].values, assembly['neuroid_id'].values)
+    np.testing.assert_array_equal(averaged_assembly.sel(image_id='a').values, [[1.5, 2.5, 3.5]])
+    np.testing.assert_array_equal(averaged_assembly.sel(image_id='b').values, [[3.5, 4.5, 5.5]])
+    np.testing.assert_array_equal(averaged_assembly.sel(image_id='c').values, [[5.5, 6.5, 7.5]])
+    np.testing.assert_array_equal(averaged_assembly.sel(image_id='d').values, [[7.5, 8.5, 9.5]])

--- a/tests/test_benchmarks/test_trials.py
+++ b/tests/test_benchmarks/test_trials.py
@@ -32,7 +32,7 @@ def test_integer_repeat():
     assert repeat_stimulus_set.identifier == 'dummy-5trials'
 
 
-def test_average_trials():
+def test_average_neural_trials():
     assembly = NeuroidAssembly([[1, 2, 3],
                                 [2, 3, 4],
                                 [3, 4, 5],
@@ -56,3 +56,24 @@ def test_average_trials():
     np.testing.assert_array_equal(averaged_assembly.sel(image_id='b').values, [[3.5, 4.5, 5.5]])
     np.testing.assert_array_equal(averaged_assembly.sel(image_id='c').values, [[5.5, 6.5, 7.5]])
     np.testing.assert_array_equal(averaged_assembly.sel(image_id='d').values, [[7.5, 8.5, 9.5]])
+
+
+def test_average_label_trials():
+    assembly = NeuroidAssembly([['a'],
+                                ['a'],
+                                ['a'],
+                                ['b'],
+                                ['b'],
+                                ['a'],
+                                ],
+                               coords={'image_id': ('presentation', ['a', 'a', 'a', 'b', 'b', 'b']),
+                                       'repetition': ('presentation', [0, 1, 2, 0, 1, 2]),
+                                       'presentation_dummy': ('presentation', ['x'] * 6),
+                                       'choice': ('choice', ['dummy'])},
+                               dims=['presentation', 'choice'])
+    averaged_assembly = average_trials(assembly)
+    assert len(averaged_assembly['choice']) == 1, "messed up dimension"
+    assert len(averaged_assembly['presentation']) == 2
+    assert set(averaged_assembly['image_id'].values) == {'a', 'b'}
+    np.testing.assert_array_equal(averaged_assembly.sel(image_id='a').values, [['a']])
+    np.testing.assert_array_equal(averaged_assembly.sel(image_id='b').values, [['b']])


### PR DESCRIPTION
- [x] repeat stimulus_set with fixed number of repetitions
- [ ] ~repeat stimulus_set with per-image repetitions~
- [x] average model per-trial responses
- [x] update current benchmarks to use trials
- [x] ensure unit-tests pass
- [x] adjust model-tools for efficient trials
- [x] adjust model-tools for ImageNet assembly