### PR TITLE
if candidate recordings are not temporal, exit early in Kar2019

### DIFF
--- a/brainscore/benchmarks/kar2019.py
+++ b/brainscore/benchmarks/kar2019.py
@@ -7,7 +7,28 @@ from brainscore.metrics import Score
 from brainscore.metrics.ost import OSTCorrelation
 from brainscore.model_interface import BrainModel
 
+BIBTEX = """@Article{Kar2019,
+            author={Kar, Kohitij
+            and Kubilius, Jonas
+            and Schmidt, Kailyn
+            and Issa, Elias B.
+            and DiCarlo, James J.},
+            title={Evidence that recurrent circuits are critical to the ventral stream's execution of core object recognition behavior},
+            journal={Nature Neuroscience},
+            year={2019},
+            month={Jun},
+            day={01},
+            volume={22},
+            number={6},
+            pages={974-983},
+            abstract={Non-recurrent deep convolutional neural networks (CNNs) are currently the best at modeling core object recognition, a behavior that is supported by the densely recurrent primate ventral stream, culminating in the inferior temporal (IT) cortex. If recurrence is critical to this behavior, then primates should outperform feedforward-only deep CNNs for images that require additional recurrent processing beyond the feedforward IT response. Here we first used behavioral methods to discover hundreds of these `challenge' images. Second, using large-scale electrophysiology, we observed that behaviorally sufficient object identity solutions emerged {\textasciitilde}30{\thinspace}ms later in the IT cortex for challenge images compared with primate performance-matched `control' images. Third, these behaviorally critical late-phase IT response patterns were poorly predicted by feedforward deep CNN activations. Notably, very-deep CNNs and shallower recurrent CNNs better predicted these late IT responses, suggesting that there is a functional equivalence between additional nonlinear transformations and recurrence. Beyond arguing that recurrent circuits are critical for rapid object identification, our results provide strong constraints for future recurrent model development.},
+            issn={1546-1726},
+            doi={10.1038/s41593-019-0392-5},
+            url={https://doi.org/10.1038/s41593-019-0392-5}
+            }"""
 VISUAL_DEGREES = 8
+NUMBER_OF_TRIALS = 44
+TIME_BINS = [(time_bin_start, time_bin_start + 10) for time_bin_start in range(70, 250, 10)]
 
 
 class DicarloKar2019OST(BenchmarkBase):
@@ -16,26 +37,8 @@ class DicarloKar2019OST(BenchmarkBase):
                         coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
         super(DicarloKar2019OST, self).__init__(identifier='dicarlo.Kar2019-ost', version=2,
                                                 ceiling_func=lambda: ceiling,
-                                                parent='IT-temporal',
-                                                bibtex="""@Article{Kar2019,
-                                                    author={Kar, Kohitij
-                                                    and Kubilius, Jonas
-                                                    and Schmidt, Kailyn
-                                                    and Issa, Elias B.
-                                                    and DiCarlo, James J.},
-                                                    title={Evidence that recurrent circuits are critical to the ventral stream's execution of core object recognition behavior},
-                                                    journal={Nature Neuroscience},
-                                                    year={2019},
-                                                    month={Jun},
-                                                    day={01},
-                                                    volume={22},
-                                                    number={6},
-                                                    pages={974-983},
-                                                    abstract={Non-recurrent deep convolutional neural networks (CNNs) are currently the best at modeling core object recognition, a behavior that is supported by the densely recurrent primate ventral stream, culminating in the inferior temporal (IT) cortex. If recurrence is critical to this behavior, then primates should outperform feedforward-only deep CNNs for images that require additional recurrent processing beyond the feedforward IT response. Here we first used behavioral methods to discover hundreds of these `challenge' images. Second, using large-scale electrophysiology, we observed that behaviorally sufficient object identity solutions emerged {\textasciitilde}30{\thinspace}ms later in the IT cortex for challenge images compared with primate performance-matched `control' images. Third, these behaviorally critical late-phase IT response patterns were poorly predicted by feedforward deep CNN activations. Notably, very-deep CNNs and shallower recurrent CNNs better predicted these late IT responses, suggesting that there is a functional equivalence between additional nonlinear transformations and recurrence. Beyond arguing that recurrent circuits are critical for rapid object identification, our results provide strong constraints for future recurrent model development.},
-                                                    issn={1546-1726},
-                                                    doi={10.1038/s41593-019-0392-5},
-                                                    url={https://doi.org/10.1038/s41593-019-0392-5}
-                                                    }""")
+                                                parent='IT',
+                                                bibtex=BIBTEX)
         assembly = brainscore.get_assembly('dicarlo.Kar2019')
         # drop duplicate images
         _, index = np.unique(assembly['image_id'], return_index=True)
@@ -49,15 +52,37 @@ class DicarloKar2019OST(BenchmarkBase):
         self._assembly.stimulus_set['truth'] = self._assembly.stimulus_set['image_label']
 
         self._similarity_metric = OSTCorrelation()
+
         self._visual_degrees = VISUAL_DEGREES
-        self._number_of_trials = 44
+        self._number_of_trials = NUMBER_OF_TRIALS
+        self._time_bins = TIME_BINS
 
     def __call__(self, candidate: BrainModel):
-        time_bins = [(time_bin_start, time_bin_start + 10) for time_bin_start in range(70, 250, 10)]
-        candidate.start_recording('IT', time_bins=time_bins)
+        candidate.start_recording('IT', time_bins=self._time_bins)
         stimulus_set = place_on_screen(self._assembly.stimulus_set, target_visual_degrees=candidate.visual_degrees(),
                                        source_visual_degrees=self._visual_degrees)
+        # Temporal recordings from large candidates take up a lot of memory and compute time.
+        # In order to quickly reject recordings that are static over time,
+        # we will show one image and check whether the recordings vary over time at all or not.
+        # If they don't we can quickly score the candidate with a failure state
+        # since it will not be able to predict temporal differences with the OST metric
+        check_recordings = candidate.look_at(stimulus_set[:1], number_of_trials=self._number_of_trials)
+        if not temporally_varying(check_recordings):
+            return Score([np.nan, np.nan], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
+
         recordings = candidate.look_at(stimulus_set, number_of_trials=self._number_of_trials)
         score = self._similarity_metric(recordings, self._assembly)
         score = ceil_score(score, self.ceiling)
         return score
+
+
+def temporally_varying(recordings):
+    """
+    Tests whether the given recordings change over time, for any of the stimuli on any of the neuroids
+
+    :return True if any of the neuroids changes over time for any of the stimuli, False otherwise
+    """
+    recordings = recordings.transpose('presentation', 'neuroid', 'time_bin')
+    first_response = recordings.sel(time_bin=recordings['time_bin'].values[0])
+    different = recordings != first_response
+    return different.any()

--- a/brainscore/benchmarks/kar2019.py
+++ b/brainscore/benchmarks/kar2019.py
@@ -68,10 +68,10 @@ class DicarloKar2019OST(BenchmarkBase):
         # since it will not be able to predict temporal differences with the OST metric
         check_recordings = candidate.look_at(stimulus_set[:1], number_of_trials=self._number_of_trials)
         if not temporally_varying(check_recordings):
-            return Score([np.nan, np.nan], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
-
-        recordings = candidate.look_at(stimulus_set, number_of_trials=self._number_of_trials)
-        score = self._similarity_metric(recordings, self._assembly)
+            score = Score([np.nan, np.nan], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
+        else:
+            recordings = candidate.look_at(stimulus_set, number_of_trials=self._number_of_trials)
+            score = self._similarity_metric(recordings, self._assembly)
         score = ceil_score(score, self.ceiling)
         return score
 

--- a/brainscore/metrics/ost.py
+++ b/brainscore/metrics/ost.py
@@ -26,8 +26,6 @@ class OSTCorrelation(Metric):
         self._predicted_osts, self._target_osts = [], []
 
     def __call__(self, source_recordings, target_osts):
-        if len(set(source_recordings['time_bin'].values)) <= 1:  # short-cut for non-temporal models
-            return Score([np.nan, np.nan], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
         score = self._cross_validation(source_recordings, target_osts, apply=self.apply)
         return score
 

--- a/tests/test_benchmarks/__init__.py
+++ b/tests/test_benchmarks/__init__.py
@@ -19,7 +19,8 @@ class PrecomputedFeatures(BrainModel):
         pass
 
     def look_at(self, stimuli, number_of_trials=1):
-        assert set(self.features['image_id'].values) == set(stimuli['image_id'].values)
+        missing_image_ids = set(stimuli['image_id'].values) - set(self.features['image_id'].values)
+        assert not missing_image_ids, f"stored features do not contain image_ids {missing_image_ids}"
         features = self.features.isel(presentation=[np.where(self.features['image_id'].values == image_id)[0][0]
                                                     for image_id in stimuli['image_id'].values])
         assert all(features['image_id'].values == stimuli['image_id'].values)

--- a/tests/test_benchmarks/test_kar2019.py
+++ b/tests/test_benchmarks/test_kar2019.py
@@ -10,7 +10,7 @@ from tests.test_benchmarks import PrecomputedFeatures
 
 @pytest.mark.memory_intense
 @pytest.mark.private_access
-def test_notime():
+def test_no_time():
     benchmark = DicarloKar2019OST()
     rnd = RandomState(0)
     stimuli = benchmark._assembly.stimulus_set
@@ -22,6 +22,28 @@ def test_notime():
         'layer': ('neuroid', ['test'] * 5),
         'time_bin_start': ('time_bin', [70]),
         'time_bin_end': ('time_bin', [170]),
+    }, dims=['presentation', 'neuroid', 'time_bin'])
+    source.name = __name__ + ".test_notime"
+    score = benchmark(PrecomputedFeatures(source, visual_degrees=8))
+    assert np.isnan(score.sel(aggregation='center'))  # not a temporal model
+    assert np.isnan(score.raw.sel(aggregation='center'))  # not a temporal model
+    assert score.attrs['ceiling'].sel(aggregation='center') == approx(.79)
+
+
+@pytest.mark.memory_intense
+@pytest.mark.private_access
+def test_random_time():
+    benchmark = DicarloKar2019OST()
+    rnd = RandomState(0)
+    stimuli = benchmark._assembly.stimulus_set
+    source = DataAssembly(rnd.rand(len(stimuli), 5, 5), coords={
+        'image_id': ('presentation', stimuli['image_id']),
+        'image_label': ('presentation', stimuli['image_label']),
+        'truth': ('presentation', stimuli['truth']),
+        'neuroid_id': ('neuroid', list(range(5))),
+        'layer': ('neuroid', ['test'] * 5),
+        'time_bin_start': ('time_bin', [70, 90, 110, 130, 150]),
+        'time_bin_end': ('time_bin', [90, 110, 130, 150, 170]),
     }, dims=['presentation', 'neuroid', 'time_bin'])
     source.name = __name__ + ".test_notime"
     score = benchmark(PrecomputedFeatures(source, visual_degrees=8))


### PR DESCRIPTION
evaluating models on Kar2019 takes notoriously long and often fails with out-of-memory errors (see e.g. http://braintree.mit.edu:8080/job/run_benchmarks/813 for a recent example) -- but ultimately most models (feedforward) get a nan score (cannot predict) anyway.

The out-of-memory errors occur especially for models with large activations when repeating their activations over time (https://github.com/brain-score/model-tools/blob/87e0a0fb5aec46e6c2c4aae06a3eb2040752e52c/model_tools/brain_transformation/temporal.py#L39-L47).

To solve the unnecessary use of compute resources for feedforward models, this PR runs a single image on the model candidate and checks whether any of the neuroids vary over time. If not, it exits early with a nan score.