### PR TITLE
increase ImageNet-C version number (addendum to #267)

### DIFF
--- a/brainscore/benchmarks/imagenet_c.py
+++ b/brainscore/benchmarks/imagenet_c.py
@@ -37,14 +37,18 @@ BIBTEX = """@ARTICLE{Hendrycks2019-di,
    url           = "https://arxiv.org/abs/1903.12261"
 }"""
 
+
 def Imagenet_C_Noise(sampling_factor=10):
     return Imagenet_C_Category('noise', sampling_factor=sampling_factor)
+
 
 def Imagenet_C_Blur(sampling_factor=10):
     return Imagenet_C_Category('blur', sampling_factor=sampling_factor)
 
+
 def Imagenet_C_Weather(sampling_factor=10):
     return Imagenet_C_Category('weather', sampling_factor=sampling_factor)
+
 
 def Imagenet_C_Digital(sampling_factor=10):
     return Imagenet_C_Category('digital', sampling_factor=sampling_factor)
@@ -58,23 +62,24 @@ class Imagenet_C_Category(BenchmarkBase):
     impulse noise [1-5]
     """
     noise_category_map = {
-        'noise' : ['gaussian_noise', 'shot_noise', 'impulse_noise'],
-        'blur' : ['glass_blur', 'motion_blur', 'zoom_blur', 'defocus_blur'],
-        'weather' : ['snow', 'frost', 'fog', 'brightness'],
-        'digital' : ['pixelate', 'contrast', 'elastic_transform', 'jpeg_compression']
+        'noise': ['gaussian_noise', 'shot_noise', 'impulse_noise'],
+        'blur': ['glass_blur', 'motion_blur', 'zoom_blur', 'defocus_blur'],
+        'weather': ['snow', 'frost', 'fog', 'brightness'],
+        'digital': ['pixelate', 'contrast', 'elastic_transform', 'jpeg_compression']
     }
 
     def __init__(self, noise_category, sampling_factor=10):
         self.noise_category = noise_category
         self.stimulus_set_name = f'dietterich.Hendrycks2019.{noise_category}'
-        
+
         # take every nth image, n=sampling_factor.
         stimulus_set = brainscore.get_stimulus_set(self.stimulus_set_name)[::sampling_factor]
         self.stimulus_set = stimulus_set
         self.noise_types = self.noise_category_map[noise_category]
 
         ceiling = Score([1, np.nan], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
-        super(Imagenet_C_Category, self).__init__(identifier=f'dietterich.Hendrycks2019-{noise_category}-top1', version=1,
+        super(Imagenet_C_Category, self).__init__(identifier=f'dietterich.Hendrycks2019-{noise_category}-top1',
+                                                  version=2,
                                                   ceiling_func=lambda: ceiling,
                                                   parent='dietterich.Hendrycks2019-top1',
                                                   bibtex=BIBTEX)
@@ -91,24 +96,27 @@ class Imagenet_C_Category(BenchmarkBase):
         score.attrs[Score.RAW_VALUES_KEY] = scores
         return score
 
+
 class Imagenet_C_Type(BenchmarkBase):
     """
     Runs a group in imnet C benchmarks, like gaussian noise [1-5]
     """
+
     def __init__(self, stimulus_set, noise_type, noise_category):
-        self.stimulus_set = stimulus_set[stimulus_set['noise_type']==noise_type]
+        self.stimulus_set = stimulus_set[stimulus_set['noise_type'] == noise_type]
         self.noise_type = noise_type
         self.noise_category = noise_category
         ceiling = Score([1, np.nan], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
-        super(Imagenet_C_Type, self).__init__(identifier=f'dietterich.Hendrycks2019-{noise_category}-{noise_type}-top1', version=1,
-                                           ceiling_func=lambda: ceiling,
-                                           parent=f'dietterich.Hendrycks2019-{noise_category}-top1',
-                                           bibtex=BIBTEX)
+        super(Imagenet_C_Type, self).__init__(identifier=f'dietterich.Hendrycks2019-{noise_category}-{noise_type}-top1',
+                                              version=2,
+                                              ceiling_func=lambda: ceiling,
+                                              parent=f'dietterich.Hendrycks2019-{noise_category}-top1',
+                                              bibtex=BIBTEX)
 
     def __call__(self, candidate):
         score = xr.concat([
             Imagenet_C_Individual(self.stimulus_set, noise_level, self.noise_type, self.noise_category)(candidate)
-            for noise_level in range(1,6)
+            for noise_level in range(1, 6)
         ], dim='presentation')
         return score
 
@@ -117,25 +125,27 @@ class Imagenet_C_Individual(BenchmarkBase):
     """
     Runs an individual ImageNet C benchmark, like "gaussian_noise_1"
     """
+
     def __init__(self, stimulus_set, noise_level, noise_type, noise_category):
-        self.stimulus_set = stimulus_set[stimulus_set['noise_level']==noise_level]
+        self.stimulus_set = stimulus_set[stimulus_set['noise_level'] == noise_level]
         self.noise_level = noise_level
         self.noise_type = noise_type
         self.benchmark_name = f'dietterich.Hendrycks2019-{noise_category}-{noise_type}-{noise_level}-top1'
-        self._similarity_metric = Accuracy() 
+        self._similarity_metric = Accuracy()
         ceiling = Score([1, np.nan], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
-        super(Imagenet_C_Individual, self).__init__(identifier=self.benchmark_name, version=1,
+        super(Imagenet_C_Individual, self).__init__(identifier=self.benchmark_name, version=2,
                                                     ceiling_func=lambda: ceiling,
                                                     parent=f'dietterich.Hendrycks2019-{noise_category}-{noise_type}-top1',
                                                     bibtex=BIBTEX)
 
     def __call__(self, candidate):
         candidate.start_task(BrainModel.Task.label, 'imagenet')
-        stimulus_set = self.stimulus_set[list(set(self.stimulus_set.columns) - {'synset'})].copy().reset_index()  # do not show label
+        stimulus_set = self.stimulus_set[
+            list(set(self.stimulus_set.columns) - {'synset'})].copy().reset_index()  # do not show label
         stimulus_set.identifier = f'{self.benchmark_name}-{len(stimulus_set)}samples'
         predictions = candidate.look_at(stimulus_set, number_of_trials=NUMBER_OF_TRIALS)
         score = self._similarity_metric(
-            predictions.sortby('filename'), 
+            predictions.sortby('filename'),
             self.stimulus_set.sort_values('filename')['synset'].values
         ).raw
 


### PR DESCRIPTION
We forgot to do this in #267 -- due to changes to the ImageNet-C benchmarks (sub-sampling), benchmark results will be different and the version number thus needs to be increased.