### PR TITLE
package Kar2018 coco-color behavioral data; add match-to-sample benchmarks

### DIFF
--- a/brainscore/benchmarks/__init__.py
+++ b/brainscore/benchmarks/__init__.py
@@ -194,6 +194,8 @@ def _evaluation_benchmark_pool():
     # behavioral benchmarks
     from .rajalingham2018 import DicarloRajalingham2018I2n
     pool['dicarlo.Rajalingham2018-i2n'] = LazyLoad(DicarloRajalingham2018I2n)
+    from .kar2018 import DicarloKar2018I2n
+    pool['dicarlo.Kar2018-i2n'] = LazyLoad(DicarloKar2018I2n)
 
     return pool
 
@@ -266,8 +268,9 @@ def _public_benchmark_pool():
     pool['dicarlo.MajajHong2015public.IT-pls'] = LazyLoad(MajajHongITPublicBenchmark)
 
     # behavioral benchmarks
-    from .public_benchmarks import RajalinghamMatchtosamplePublicBenchmark
-    pool['dicarlo.Rajalingham2018public-i2n'] = LazyLoad(RajalinghamMatchtosamplePublicBenchmark)
+    from .public_benchmarks import Rajalingham2018MatchtosamplePublicBenchmark, Kar2018MatchtosamplePublicBenchmark
+    pool['dicarlo.Rajalingham2018public-i2n'] = LazyLoad(Rajalingham2018MatchtosamplePublicBenchmark)
+    pool['dicarlo.Kar2018public-i2n'] = LazyLoad(Kar2018MatchtosamplePublicBenchmark)
 
     return pool
 

--- a/brainscore/benchmarks/kar2018.py
+++ b/brainscore/benchmarks/kar2018.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+import brainscore
+from brainscore.benchmarks import BenchmarkBase
+from brainscore.benchmarks.screen import place_on_screen
+from brainscore.metrics import Score
+from brainscore.metrics.image_level_behavior import I2n
+from brainscore.metrics.transformations import apply_aggregate
+from brainscore.model_interface import BrainModel
+from brainscore.utils import LazyLoad
+
+BIBTEX = None
+
+
+class _DicarloKar2018(BenchmarkBase):
+    def __init__(self, metric, metric_identifier):
+        self._metric = metric
+        self._fitting_stimuli = brainscore.get_stimulus_set('dicarlo.Kar2018coco_color.public')
+        self._assembly = LazyLoad(lambda: load_assembly('private'))
+        self._visual_degrees = 8
+        self._number_of_trials = 2
+        super(_DicarloKar2018, self).__init__(
+            identifier='dicarlo.Kar2018-' + metric_identifier, version=1,
+            ceiling_func=lambda: self._metric.ceiling(self._assembly),
+            parent='behavior',
+            bibtex=BIBTEX)
+
+    def __call__(self, candidate: BrainModel):
+        fitting_stimuli = place_on_screen(self._fitting_stimuli, target_visual_degrees=candidate.visual_degrees(),
+                                          source_visual_degrees=self._visual_degrees)
+        candidate.start_task(BrainModel.Task.probabilities, fitting_stimuli)
+        stimulus_set = place_on_screen(self._assembly.stimulus_set, target_visual_degrees=candidate.visual_degrees(),
+                                       source_visual_degrees=self._visual_degrees)
+        probabilities = candidate.look_at(stimulus_set, number_of_trials=self._number_of_trials)
+        score = self._metric(probabilities, self._assembly)
+        ceiling = self.ceiling
+        score = self.ceil_score(score, ceiling)
+        return score
+
+    def ceil_score(self, score, ceiling):
+        assert set(score.raw['split'].values) == set(ceiling.raw['split'].values)
+        split_scores = []
+        for split in ceiling.raw['split'].values:
+            split_score = score.raw.sel(split=split)
+            split_ceiling = ceiling.raw.sel(split=split)
+            ceiled_split_score = split_score / np.sqrt(split_ceiling)
+            ceiled_split_score = ceiled_split_score.expand_dims('split')
+            ceiled_split_score['split'] = [split]
+            split_scores.append(ceiled_split_score)
+        split_scores = Score.merge(*split_scores)
+        split_scores = apply_aggregate(self._metric.aggregate, split_scores)
+        split_scores.attrs[Score.RAW_VALUES_KEY] = score  # this will override raw per-split ceiled scores which is ok
+        split_scores.attrs['ceiling'] = ceiling
+        return split_scores
+
+
+def DicarloKar2018I2n():
+    return _DicarloKar2018(metric=I2n(), metric_identifier='i2n')
+
+
+def load_assembly(access='private'):
+    assembly = brainscore.get_assembly(f'dicarlo.Kar2018coco_behavior.{access}')
+    assembly['correct'] = assembly['choice'] == assembly['sample_obj']
+    return assembly

--- a/brainscore/benchmarks/public_benchmarks.py
+++ b/brainscore/benchmarks/public_benchmarks.py
@@ -10,26 +10,23 @@ import functools
 import logging
 
 import boto3
+import brainio
 from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import ClientError
-
-import brainio
 from brainio.fetch import BotoFetcher
+
 from brainscore.benchmarks._neural_common import NeuralBenchmark
 from brainscore.metrics.ceiling import InternalConsistency
+from brainscore.metrics.image_level_behavior import I2n
 from brainscore.metrics.regression import CrossRegressedCorrelation, pls_regression, pearsonr_correlation
 from brainscore.utils import LazyLoad
 from .freemanziemba2013 import load_assembly as load_freemanziemba2013, VISUAL_DEGREES as freemanziemba2013_degrees, \
-    NUMBER_OF_TRIALS as freemanziemba2013_trials
+    NUMBER_OF_TRIALS as freemanziemba2013_trials, BIBTEX as freemanziemba2013_bibtex
+from .kar2018 import load_assembly as load_kar2018, _DicarloKar2018
 from .majajhong2015 import load_assembly as load_majajhong2015, VISUAL_DEGREES as majajhong2015_degrees, \
-    NUMBER_OF_TRIALS as majajhong2015_trials
-from .freemanziemba2013 import load_assembly as load_freemanziemba2013, VISUAL_DEGREES as freemanziemba2013_degrees, \
-    BIBTEX as freemanziemba2013_bibtex
-from .majajhong2015 import load_assembly as load_majajhong2015, VISUAL_DEGREES as majajhong2015_degrees, \
-    BIBTEX as majajhong2015_bibtex
+    NUMBER_OF_TRIALS as majajhong2015_trials, BIBTEX as majajhong2015_bibtex
 from .rajalingham2018 import load_assembly as load_rajalingham2018, _DicarloRajalingham2018
-from brainscore.metrics.image_level_behavior import I2n
 
 _logger = logging.getLogger(__name__)
 
@@ -77,11 +74,18 @@ def MajajHongITPublicBenchmark():
                                stratification_coord='object_name', bibtex=majajhong2015_bibtex)
 
 
-class RajalinghamMatchtosamplePublicBenchmark(_DicarloRajalingham2018):
+class Rajalingham2018MatchtosamplePublicBenchmark(_DicarloRajalingham2018):
     def __init__(self):
-        super(RajalinghamMatchtosamplePublicBenchmark, self).__init__(metric=I2n(), metric_identifier='i2n')
+        super(Rajalingham2018MatchtosamplePublicBenchmark, self).__init__(metric=I2n(), metric_identifier='i2n')
         self._assembly = LazyLoad(lambda: load_rajalingham2018(access='public'))
         self._ceiling_func = lambda: self._metric.ceiling(self._assembly, skipna=True)
+
+
+class Kar2018MatchtosamplePublicBenchmark(_DicarloKar2018):
+    def __init__(self):
+        super(Kar2018MatchtosamplePublicBenchmark, self).__init__(metric=I2n(), metric_identifier='i2n')
+        self._assembly = LazyLoad(lambda: load_kar2018(access='public'))
+        self._ceiling_func = lambda: self._metric.ceiling(self._assembly)
 
 
 def list_public_assemblies():

--- a/packaging/dicarlo/kar2018_cocobehavior/__init__.py
+++ b/packaging/dicarlo/kar2018_cocobehavior/__init__.py
@@ -1,0 +1,133 @@
+import os
+
+import h5py
+import numpy as np
+import pandas as pd
+import imageio
+import xarray as xr
+from pathlib import Path
+from result_caching import store
+from sklearn.model_selection import StratifiedShuffleSplit
+from tqdm import tqdm
+
+from brainio.assemblies import BehavioralAssembly
+from brainio.stimuli import StimulusSet
+from brainio.packaging import package_stimulus_set, package_data_assembly
+
+
+@store(identifier_ignore=['stimuli_dir'])
+def collect_stimuli(data_path, stimuli_dir):
+    stimuli, local_paths = [], []
+    with h5py.File(data_path, 'r') as f:
+        meta = f['meta']
+        os.makedirs(stimuli_dir, exist_ok=True)
+        for image_id, filename, reference, obj, sample_number, object_number, phase in tqdm(zip(
+                *[meta[key][0] for key in ['id', 'filename', 'img', 'obj', 'sampleNr', 'objNr', 'phase']]),
+                desc='stimuli', total=len(meta['img'][0])):
+            # gather meta
+            image_id = ''.join([chr(i[0]) for i in f[image_id]])
+            object_name = ''.join(chr(i[0]) for i in f[f[obj][0][0]])
+            sample_number = int(f[sample_number][0][0])
+            object_number = int(f[object_number][0][0])
+            filename = ''.join([chr(i[0]) for i in f[filename]])
+            stimuli.append({
+                'image_path_within_store': filename,
+                'image_id': image_id,
+                'object_name': object_name,
+                'obj': object_name,
+                'image_label': object_name,
+                'sample_number': sample_number,
+                'object_number': object_number,
+            })
+            # write image locally (will be packaged later)
+            img = np.array(f[reference])
+            img = img.transpose([1, 2, 0])
+            target_path = os.path.join(stimuli_dir, filename)
+            imageio.imwrite(target_path, np.rot90(np.fliplr(img)))
+            local_paths.append(target_path)
+    stimuli = StimulusSet(stimuli)
+    stimuli.image_paths = {image_id: local_path for image_id, local_path in zip(stimuli['image_id'], local_paths)}
+    return stimuli
+
+
+@store(identifier_ignore=['stimuli'])
+def collect_data(data_path, stimuli):
+    responses = []
+    with h5py.File(data_path, 'r') as f:
+        data = f['data']
+        keys = ['sample_number', 'sample_object_number', 'distractor_number', 'correct']
+        for trial in tqdm(np.array(data['dataTurk'], dtype=int).transpose(), desc='trials'):
+            response = {key: value for key, value in zip(keys, trial)}
+            meta = stimuli[stimuli['sample_number'] == response['sample_number']]
+            assert len(meta) == 1
+            meta = meta.iloc[0]
+            response['sample_obj'] = response['sample_object'] = response['truth'] = meta['obj']
+            response['image_id'] = meta['image_id']
+            distractor_meta = stimuli[stimuli['object_number'] == response['distractor_number']]
+            distractor_obj = set(distractor_meta['obj'])
+            assert len(distractor_obj) == 1
+            response['dist_obj'] = response['distractor_object'] = list(distractor_obj)[0]
+            response['correct'] = bool(response['correct'])
+            response['choice'] = response['sample_obj'] if response['correct'] else response['dist_obj']
+            del response['correct']  # cannot be serialized to netcdf
+            responses.append(response)
+
+    responses = pd.DataFrame(responses)
+    responses = to_xarray(responses)
+    return responses
+
+
+def to_xarray(responses):
+    columns = list(responses.columns)
+    responses = xr.DataArray(responses['choice'],
+                             coords={column: ('presentation', responses[column]) for column in columns},
+                             dims=['presentation'])
+    responses = responses.set_index(presentation=columns)
+    responses = BehavioralAssembly(responses)
+    return responses
+
+
+def main():
+    data_dir = Path('/braintree/home/msch/share/kar2018_cocobehavior')
+    data_path = data_dir / 'coco_data.mat'
+    stimuli = collect_stimuli(data_path, stimuli_dir=data_dir / 'stimuli')
+    assembly = collect_data(data_path, stimuli)
+    assert len(stimuli) == 1600
+    assert len(assembly) == 179660
+    assert len(set(assembly['image_id'].values)) == 1600
+    assert set(assembly['image_id'].values) == set(stimuli['image_id'])
+    assert len(set(assembly['choice'].values)) == len(set(assembly['sample_obj'].values)) \
+           == len(set(assembly['dist_obj'].values)) == 10
+
+    assembly.name = 'dicarlo.Kar2018coco_behavior'
+    stimuli.name = 'dicarlo.Kar2018coco_color'
+
+    # split into public/private
+    # Rajalingham2018 has 585_511 public and 341_785 private trials, with 2_160 unique public and 240 private images.
+    # We here trade-off between the number of images for fitting and the number of trials for testing
+    # by settling on a 80:20 split.
+    print("Splitting into public/private")
+    split = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=15)
+    public_idx, private_idx = next(split.split(stimuli['image_id'].values, stimuli['obj'].values))
+    public_stimuli, private_stimuli = stimuli.iloc[public_idx], stimuli.iloc[private_idx]
+    assert len(public_stimuli) == 1_280 and len(private_stimuli) == 320
+    public_stimuli.name, private_stimuli.name = stimuli.name + '.public', stimuli.name + '.private'
+    public_assembly = assembly[{'presentation': [image_id in public_stimuli['image_id'].values
+                                                 for image_id in assembly['image_id'].values]}]
+    private_assembly = assembly[{'presentation': [image_id in private_stimuli['image_id'].values
+                                                  for image_id in assembly['image_id'].values]}]
+    assert len(public_assembly) == 143_492 and len(private_assembly) == 36_168
+    public_assembly.name, private_assembly.name = assembly.name + '.public', assembly.name + '.private'
+
+    # package
+    return
+    print("Packaging")
+    for stimuli, assembly in zip([public_stimuli, private_stimuli], [public_assembly, private_assembly]):
+        package_stimulus_set(stimuli, stimulus_set_identifier=stimuli.name,
+                             bucket_name="brainio.dicarlo")
+        package_data_assembly(assembly, assembly_identifier=assembly.name, stimulus_set_identifier=stimuli.name,
+                              assembly_class='BehavioralAssembly', bucket_name="brainio.dicarlo")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- [ ] decide how to split stimuli & assembly -- trade-off between images for fitting and number of trials for testing
- [ ] double-check visual degrees
- [ ] double-check number of trials
- [ ] decide what to reference -- this data was first used in Kubilius*, Schrimpf*, et al. NeurIPS 2019; but maybe Ko prefers to write a small report to reference instead
- [ ] add unit tests