### PR TITLE
let ErrorConsistency Score output have center and error

### DIFF
--- a/brainscore/metrics/error_consistency.py
+++ b/brainscore/metrics/error_consistency.py
@@ -33,7 +33,7 @@ class ErrorConsistency(Metric):
     @classmethod
     def aggregate(cls, scores):
         center = scores.mean('condition').mean('subject')
-        error = scores.std(['condition', 'subject'])
+        error = scores.std(['condition', 'subject'])  # note that the original paper did not have error estimates
         return Score([center, error], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
 
     def ceiling(self, assembly):

--- a/brainscore/metrics/error_consistency.py
+++ b/brainscore/metrics/error_consistency.py
@@ -27,9 +27,14 @@ class ErrorConsistency(Metric):
                 subject_score['condition'] = [condition]
                 subject_scores.append(subject_score)
         subject_scores = Score.merge(*subject_scores)
-        subject_scores = apply_aggregate(aggregate_fnc=lambda scores: scores.mean('condition').mean('subject'),
-                                         values=subject_scores)
+        subject_scores = apply_aggregate(aggregate_fnc=self.aggregate, values=subject_scores)
         return subject_scores
+
+    @classmethod
+    def aggregate(cls, scores):
+        center = scores.mean('condition').mean('subject')
+        error = scores.std(['condition', 'subject'])
+        return Score([center, error], coords={'aggregation': ['center', 'error']}, dims=['aggregation'])
 
     def ceiling(self, assembly):
         """

--- a/tests/test_benchmarks/test_geirhos2021.py
+++ b/tests/test_benchmarks/test_geirhos2021.py
@@ -79,8 +79,11 @@ class TestBehavioral:
                                                    visual_degrees=8,  # doesn't matter, features are already computed
                                                    )
         # score
-        score = benchmark(precomputed_features).raw
-        assert score == expected_raw_score
+        score = benchmark(precomputed_features)
+        raw_score = score.raw
+        # division by ceiling <= 1 should result in higher score
+        assert score.sel(aggregation='center') >= raw_score.sel(aggregation='center')
+        assert raw_score.sel(aggregation='center') == expected_raw_score
 
     @pytest.mark.parametrize('model, expected_raw_score', [
         ('resnet-50-pytorch-3deg', approx(0.20834, abs=0.001)),
@@ -94,7 +97,7 @@ class TestBehavioral:
             precomputed_features = BehavioralAssembly.from_files(file_path=precomputed_features)
             precomputed_features = PrecomputedFeatures(precomputed_features, visual_degrees=8)
             score = benchmark(precomputed_features).raw
-            scores.append(score)
+            scores.append(score.sel(aggregation='center'))
         mean_score = np.mean(scores)
         assert mean_score == expected_raw_score
 


### PR DESCRIPTION
Otherwise the submission evaluation fails because it wants to write `score.sel(aggregation='center')` to the database, see e.g. http://braintree.mit.edu:8080/job/run_benchmarks/2484/console

Choose std over condition and subject for error. The original paper did not have error estimates as far as I can tell