### PR TITLE
fix coordinate type for geirhos2021 stimulus_set condition

### DIFF
--- a/brainscore/benchmarks/geirhos2021.py
+++ b/brainscore/benchmarks/geirhos2021.py
@@ -116,6 +116,7 @@ def load_assembly(dataset):
     # convert condition float to string to avoid xarray indexing errors.
     # See https://app.travis-ci.com/github/brain-score/brain-score/builds/256059224
     assembly = cast_coordinate_type(assembly, coordinate='condition', newtype=str)
+    assembly.attrs['stimulus_set']['condition'] = assembly.attrs['stimulus_set']['condition'].astype(str)
     return assembly
 
 


### PR DESCRIPTION
We had cast the assembly's `condition` to type `str` to deal with xarray indexing errors, but forgot to do it for the stimulus set. This meant that the coordinate on the model assembly was still of type `int`.