### PR TITLE
use new jenkins_id instead of id for submissions

### DIFF
--- a/brainscore/submission/configuration.py
+++ b/brainscore/submission/configuration.py
@@ -42,8 +42,6 @@ class SubmissionConfig(BaseConfig):
 
     def __init__(self, model_type, user_id, jenkins_id, public: bool, competition_submission: str, **kwargs):
         super(SubmissionConfig, self).__init__(jenkins_id=jenkins_id, **kwargs)
-
-        # ID now auto-increments, no need to explicit parameter
         self.submission = Submission.create(jenkins_id=jenkins_id, submitter=user_id, timestamp=datetime.datetime.now(),
                                             model_type=model_type, status='running')
         self.competition_submission = competition_submission

--- a/brainscore/submission/configuration.py
+++ b/brainscore/submission/configuration.py
@@ -42,7 +42,9 @@ class SubmissionConfig(BaseConfig):
 
     def __init__(self, model_type, user_id, jenkins_id, public: bool, competition_submission: str, **kwargs):
         super(SubmissionConfig, self).__init__(jenkins_id=jenkins_id, **kwargs)
-        self.submission = Submission.create(id=jenkins_id, submitter=user_id, timestamp=datetime.datetime.now(),
+
+        # ID now auto-increments, no need to explicit parameter
+        self.submission = Submission.create(jenkins_id=jenkins_id, submitter=user_id, timestamp=datetime.datetime.now(),
                                             model_type=model_type, status='running')
         self.competition_submission = competition_submission
         self.public = public

--- a/brainscore/submission/models.py
+++ b/brainscore/submission/models.py
@@ -69,12 +69,15 @@ class User(PeeweeBase):
 
 
 class Submission(PeeweeBase):
-    id = PrimaryKeyField()  # We use jenkins id as id for the submission.
+    id = PrimaryKeyField()
     # IDs will not be incremental when resubmitting models
     submitter = ForeignKeyField(column_name='submitter_id', field='id', model=User)
     timestamp = DateTimeField(null=True)
     model_type = CharField()
     status = CharField()
+
+    # equivalent to ID until language changes were added: (ID 6756)
+    jenkins_id = IntegerField()
 
     class Meta:
         table_name = 'brainscore_submission'

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,4 @@
 # Unit Tests
-## Precomputed files
-Some files have been pre-computed, but are too large to add to git.
-They are on S3 instead and are automatically downloaded by executing `bash test_setup.sh`.
-
-When adding new files, they need to be made publicly accessible on S3: 
-select all files that you have added > Actions > Make public using ACL > Make public.
-
 ## Markers
 Unit tests have various markers that denote possible issues in the travis build:
 
@@ -24,3 +17,29 @@ def test_something(...):
 
 To skip a specific marker, run e.g. `pytest -m "not memory_intense"`.
 To skip multiple markers, run e.g. `pytest -m "not private_access and not memory_intense"`.
+
+
+## Precomputed features
+For many benchmark tests, it can be useful to evaluate on "reasonable" features that have been computed beforehand.
+They are on S3 instead and are automatically downloaded by executing `bash test_setup.sh`.
+Often these precomputed features are taken from models that were run on the benchmark.
+
+To capture a model's activations, you can use the following steps:
+1. in the benchmark, put a breakpoint right after `candidate.look_at`. 
+   E.g. if you run a benchmark with `predictions = candidate.look_at(stimulus_set)`, capture the `predictions`
+2. run the model you want on the benchmark, stopping at the breakpoint
+3. store the model predictions to netcdf:
+    ```python
+    from brainio.packaging import write_netcdf
+    
+    write_netcdf(predictions, '<path/to/tests/<file>.nc')
+    ```
+4. upload the `.nc` file to the S3 brain-score-tests 
+   [bucket](https://s3.console.aws.amazon.com/s3/buckets/brain-score-tests?region=us-east-1&prefix=tests/test_benchmarks/&showversions=false) 
+   (drag and drop in browser is likely easiest; you might have to ask an admin to upload.)
+   In the upload, make sure to make the file(s) publicly accessible: 
+   under Permissions > Predefined ACLs > Grant public-read access
+5. add filename to [`test_setup.sh`](https://github.com/brain-score/brain-score/blob/master/test_setup.sh) 
+6. write your unit test (see e.g. 
+   [here](https://github.com/brain-score/brain-score/blob/9ba55450a9d1c2b695c393df92aba2102ccdb169/tests/test_benchmarks/test_geirhos2021.py#L73) 
+   for an example)


### PR DESCRIPTION
Allows submission system to now write the newly updated `jenkins_id` column, as well as the auto-incrementing `id`. See https://github.com/brain-score/brain-score.web/pull/159 for more info