### PR TITLE
Hotfix: Make sure directories created use jenkins_id and not id for submission zip files. 

### DIFF
--- a/brainscore/submission/__main__.py
+++ b/brainscore/submission/__main__.py
@@ -36,7 +36,7 @@ def score_model_console():
     assert isinstance(args.jenkins_id, int)
     logger.info(f'Benchmarks configured: {args.benchmarks}')
     logger.info(f'Models configured: {args.models}')
-    run_evaluation(args.config_dir, args.work_dir, args.jenkins_id, db_secret=args.db_secret,
+    run_evaluation(args.config_dir, args.work_dir, jenkins_id=args.jenkins_id, db_secret=args.db_secret,
                    models=args.models, benchmarks=args.benchmarks)
 
 

--- a/brainscore/submission/configuration.py
+++ b/brainscore/submission/configuration.py
@@ -42,8 +42,8 @@ class SubmissionConfig(BaseConfig):
 
     def __init__(self, model_type, user_id, jenkins_id, public: bool, competition_submission: str, **kwargs):
         super(SubmissionConfig, self).__init__(jenkins_id=jenkins_id, **kwargs)
-        self.submission = Submission.create(id=jenkins_id, submitter=user_id, timestamp=datetime.datetime.now(),
-                                            model_type=model_type, status='running')
+        self.submission = Submission.create(submitter=user_id, timestamp=datetime.datetime.now(),
+                                            model_type=model_type, status='running', jenkins_id=jenkins_id)
         self.competition_submission = competition_submission
         self.public = public
 

--- a/brainscore/submission/repository.py
+++ b/brainscore/submission/repository.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 def prepare_module(submission: Submission, config: BaseConfig):
     config_path = config.config_path
-    logger.info('Start executing models in repo submission_%s' % submission.id)
-    repo = extract_zip_file(submission.id, config_path, config.work_dir)
+    logger.info('Start executing models in repo submission_%s' % submission.jenkins_id)
+    repo = extract_zip_file(submission.jenkins_id, config_path, config.work_dir)
     package = 'models.brain_models' if submission.model_type == 'BrainModel' else 'models.base_models'
     logger.info(f'We work with {submission.model_type} and access {package} in the submission folder')
     return install_project(repo, package), os.path.basename(repo)


### PR DESCRIPTION
Change the repository script to use `jenkins_id`, in accordance with updates from BSL