### PR TITLE
Hotfix: add jenkins_id to test_submission.py's tests

### DIFF
--- a/brainscore/submission/evaluation.py
+++ b/brainscore/submission/evaluation.py
@@ -71,7 +71,8 @@ def run_evaluation(config_dir, work_dir, jenkins_id, db_secret, models=None,
                     model_entry, created = Model.get_or_create(name=model_name, owner=submission_entry.submitter,
                                                                defaults={'public': submission_config.public,
                                                                          'submission': submission_entry,
-                                                                         'competition': submission_config.competition_submission})
+                                                                         'competition': submission_config.competition_submission,
+                                                                         'domain': "vision"})
                     if hasattr(module, 'get_bibtex') and created:  # model entry was just created and we can add bibtex
                         bibtex_string = module.get_bibtex(model_name)
                         reference = get_reference(bibtex_string)

--- a/brainscore/submission/models.py
+++ b/brainscore/submission/models.py
@@ -92,6 +92,7 @@ class Model(PeeweeBase):
     visual_degrees = IntegerField(null=True)  # null during creation of new model without having model object loaded
     public = BooleanField()
     competition = CharField(max_length=200, default=None, null=True)
+    domain = CharField(max_length=200, default="vision")
 
     class Meta:
         table_name = 'brainscore_model'
@@ -107,8 +108,6 @@ class Score(PeeweeBase):
     score_raw = FloatField(null=True)
     start_timestamp = DateTimeField(null=True)
     comment = CharField(null=True)
-
-    # jenkins_id = IntegerField(null=True)
 
     class Meta:
         table_name = 'brainscore_score'

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,4 @@
 # Unit Tests
-## Precomputed files
-Some files have been pre-computed, but are too large to add to git.
-They are on S3 instead and are automatically downloaded by executing `bash test_setup.sh`.
-
-When adding new files, they need to be made publicly accessible on S3: 
-select all files that you have added > Actions > Make public using ACL > Make public.
-
 ## Markers
 Unit tests have various markers that denote possible issues in the travis build:
 
@@ -24,3 +17,29 @@ def test_something(...):
 
 To skip a specific marker, run e.g. `pytest -m "not memory_intense"`.
 To skip multiple markers, run e.g. `pytest -m "not private_access and not memory_intense"`.
+
+
+## Precomputed features
+For many benchmark tests, it can be useful to evaluate on "reasonable" features that have been computed beforehand.
+They are on S3 instead and are automatically downloaded by executing `bash test_setup.sh`.
+Often these precomputed features are taken from models that were run on the benchmark.
+
+To capture a model's activations, you can use the following steps:
+1. in the benchmark, put a breakpoint right after `candidate.look_at`. 
+   E.g. if you run a benchmark with `predictions = candidate.look_at(stimulus_set)`, capture the `predictions`
+2. run the model you want on the benchmark, stopping at the breakpoint
+3. store the model predictions to netcdf:
+    ```python
+    from brainio.packaging import write_netcdf
+    
+    write_netcdf(predictions, '<path/to/tests/<file>.nc')
+    ```
+4. upload the `.nc` file to the S3 brain-score-tests 
+   [bucket](https://s3.console.aws.amazon.com/s3/buckets/brain-score-tests?region=us-east-1&prefix=tests/test_benchmarks/&showversions=false) 
+   (drag and drop in browser is likely easiest; you might have to ask an admin to upload.)
+   In the upload, make sure to make the file(s) publicly accessible: 
+   under Permissions > Predefined ACLs > Grant public-read access
+5. add filename to [`test_setup.sh`](https://github.com/brain-score/brain-score/blob/master/test_setup.sh) 
+6. write your unit test (see e.g. 
+   [here](https://github.com/brain-score/brain-score/blob/9ba55450a9d1c2b695c393df92aba2102ccdb169/tests/test_benchmarks/test_geirhos2021.py#L73) 
+   for an example)

--- a/tests/test_submission/test_integration.py
+++ b/tests/test_submission/test_integration.py
@@ -53,7 +53,7 @@ class TestIntegration:
     def test_competition_field_none(self, tmpdir):
         working_dir = str(tmpdir.mkdir('sub'))
         config_dir = str(os.path.join(os.path.dirname(__file__), 'configs/'))
-        submission = Submission.create(id=33, submitter=1, timestamp=datetime.now(),
+        submission = Submission.create(id=33, jenkins_id=33, submitter=1, timestamp=datetime.now(),
                                        model_type='BaseModel', status='running')
         model = Model.create(name='alexnet', owner=submission.submitter, public=False,
                              submission=submission)
@@ -87,7 +87,7 @@ class TestIntegration:
     def test_rerun_evaluation(self, tmpdir):
         working_dir = str(tmpdir.mkdir('sub'))
         config_dir = str(os.path.join(os.path.dirname(__file__), 'configs/'))
-        submission = Submission.create(id=33, submitter=1, timestamp=datetime.now(),
+        submission = Submission.create(id=33, jenkins_id=33, submitter=1, timestamp=datetime.now(),
                                        model_type='BaseModel', status='running')
         model = Model.create(name='alexnet', owner=submission.submitter, public=False,
                              submission=submission)

--- a/tests/test_submission/test_submission.py
+++ b/tests/test_submission/test_submission.py
@@ -78,7 +78,7 @@ class TestSubmission:
         assert instance2.benchmark.parent.identifier == 'IT'
 
     def get_test_models(self):
-        submission = Submission.create(id=33, submitter=1, timestamp=datetime.now(),
+        submission = Submission.create(id=33, jenkins_id=33, submitter=1, timestamp=datetime.now(),
                                        model_type='BaseModel', status='running')
         model_instances = []
         model_instances.append(

--- a/tests/test_submission/test_submission.py
+++ b/tests/test_submission/test_submission.py
@@ -129,6 +129,8 @@ class TestConfig:
         assert not submission_config.public
 
     def test_resubmit_config(self):
+        Submission.create(id=33, jenkins_id=33, submitter=1, timestamp=datetime.now(),
+                          model_type='BaseModel', status='running')
         model = Model.create(id=19, name='alexnet', public=True, submission=33, owner=1)
         config = {
             "model_ids": [model.id],

--- a/tests/test_submission/test_submission.py
+++ b/tests/test_submission/test_submission.py
@@ -166,7 +166,7 @@ class TestRepository:
 
     def test_prepare_module(self):
         config = BaseConfig(TestRepository.working_dir, 33, '', TestRepository.config_dir)
-        submission = Submission.create(id=33, submitter=1, timestamp=datetime.now(),
+        submission = Submission.create(id=33, jenkins_id=33, submitter=1, timestamp=datetime.now(),
                                        model_type='BaseModel', status='running')
         module, repo = prepare_module(submission, config)
         assert hasattr(module, 'get_model_list')


### PR DESCRIPTION
This PR just adds a Jenkins_id to `get_test_models` in `submission.py`