### PR TITLE
Hotfix: Remove faulty model_tools import from Islam2021 

### DIFF
--- a/brainscore/benchmarks/islam2021.py
+++ b/brainscore/benchmarks/islam2021.py
@@ -1,13 +1,10 @@
 import numpy as np
 import random
-import pandas as pd
 import brainscore
 from brainscore.benchmarks import BenchmarkBase, Score
 from brainscore.metrics.dimensionality import Dimensionality
 from brainscore.model_interface import BrainModel
-from tqdm import tqdm 
-from brainio.stimuli import StimulusSet
-from model_tools.brain_transformation import ModelCommitment
+from tqdm import tqdm
 
 BIBTEX = """@inproceedings{
             islam2021shape,


### PR DESCRIPTION
Currently, Jenkins [builds](http://braintree.mit.edu:8080/job/run_benchmarks/6922/parsed_console/) are failing due to the faulty `model_tools` import that this PR removes. The benchmark code did not use this import, and 3 other unused imports were removed as well. 