### PR TITLE
Hotfix: Add domain to new benchmark creation code for vision.

### DIFF
--- a/brainscore/submission/evaluation.py
+++ b/brainscore/submission/evaluation.py
@@ -211,7 +211,8 @@ def get_ml_pool(test_models, module, submission):
 
 def get_benchmark_instance(benchmark_name):
     benchmark = benchmark_pool[benchmark_name]
-    benchmark_type, created = BenchmarkType.get_or_create(identifier=benchmark_name, defaults=dict(order=999))
+    benchmark_type, created = BenchmarkType.get_or_create(identifier=benchmark_name,
+                                                          defaults=dict(order=999, domain="vision"))
     if created:
         try:
             parent = BenchmarkType.get(identifier=benchmark.parent)


### PR DESCRIPTION
Previously, when running a newly created benchmark for the first time,` evaluation.py` will cause Jenkins to fail. This PR fixes that by specifying a `domain` argument to the `get_or_create` method.