### PR TITLE
Hotfix: Moved Islam to experimental pool, added domain to models.py

### DIFF
--- a/brainscore/benchmarks/__init__.py
+++ b/brainscore/benchmarks/__init__.py
@@ -254,20 +254,6 @@ def _engineering_benchmark_pool():
     from .hermann2020 import Hermann2020cueconflictShapeBias, Hermann2020cueconflictShapeMatch
     pool['kornblith.Hermann2020cueconflict-shape_bias'] = LazyLoad(Hermann2020cueconflictShapeBias)
     pool['kornblith.Hermann2020cueconflict-shape_match'] = LazyLoad(Hermann2020cueconflictShapeMatch)
-
-    # Islam2021
-    from .islam2021 import Islam2021Dimensionality_V1_Shape, Islam2021Dimensionality_V1_Texture, \
-        Islam2021Dimensionality_V2_Shape, Islam2021Dimensionality_V2_Texture, \
-        Islam2021Dimensionality_V4_Shape, Islam2021Dimensionality_V4_Texture, \
-        Islam2021Dimensionality_IT_Shape, Islam2021Dimensionality_IT_Texture
-    pool['Islam2021-shape_v1_dimensionality'] = LazyLoad(Islam2021Dimensionality_V1_Shape)
-    pool['Islam2021-texture_v1_dimensionality'] = LazyLoad(Islam2021Dimensionality_V1_Texture)
-    pool['Islam2021-shape_v2_dimensionality'] = LazyLoad(Islam2021Dimensionality_V2_Shape)
-    pool['Islam2021-texture_v2_dimensionality'] = LazyLoad(Islam2021Dimensionality_V2_Texture)
-    pool['Islam2021-shape_v4_dimensionality'] = LazyLoad(Islam2021Dimensionality_V4_Shape)
-    pool['Islam2021-texture_v4_dimensionality'] = LazyLoad(Islam2021Dimensionality_V4_Texture)
-    pool['Islam2021-shape_it_dimensionality'] = LazyLoad(Islam2021Dimensionality_IT_Shape)
-    pool['Islam2021-texture_it_dimensionality'] = LazyLoad(Islam2021Dimensionality_IT_Texture)
     
     return pool
 
@@ -294,6 +280,20 @@ def _experimental_benchmark_pool():
     pool['tolias.Cadena2017-mask'] = LazyLoad(ToliasCadena2017Mask)
     from .rajalingham2020 import DicarloRajalingham2020ITPLS
     pool['dicarlo.Rajalingham2020.IT-pls'] = LazyLoad(DicarloRajalingham2020ITPLS)
+
+    # Islam 2021:
+    from .islam2021 import Islam2021Dimensionality_V1_Shape, Islam2021Dimensionality_V1_Texture, \
+        Islam2021Dimensionality_V2_Shape, Islam2021Dimensionality_V2_Texture, \
+        Islam2021Dimensionality_V4_Shape, Islam2021Dimensionality_V4_Texture, \
+        Islam2021Dimensionality_IT_Shape, Islam2021Dimensionality_IT_Texture
+    pool['Islam2021-shape_v1_dimensionality'] = LazyLoad(Islam2021Dimensionality_V1_Shape)
+    pool['Islam2021-texture_v1_dimensionality'] = LazyLoad(Islam2021Dimensionality_V1_Texture)
+    pool['Islam2021-shape_v2_dimensionality'] = LazyLoad(Islam2021Dimensionality_V2_Shape)
+    pool['Islam2021-texture_v2_dimensionality'] = LazyLoad(Islam2021Dimensionality_V2_Texture)
+    pool['Islam2021-shape_v4_dimensionality'] = LazyLoad(Islam2021Dimensionality_V4_Shape)
+    pool['Islam2021-texture_v4_dimensionality'] = LazyLoad(Islam2021Dimensionality_V4_Texture)
+    pool['Islam2021-shape_it_dimensionality'] = LazyLoad(Islam2021Dimensionality_IT_Shape)
+    pool['Islam2021-texture_it_dimensionality'] = LazyLoad(Islam2021Dimensionality_IT_Texture)
 
     return pool
 

--- a/brainscore/submission/models.py
+++ b/brainscore/submission/models.py
@@ -26,6 +26,7 @@ class BenchmarkType(PeeweeBase):
     order = IntegerField()
     parent = ForeignKeyField(column_name='parent_id', field='identifier', model='self', null=True)
     visible = BooleanField(default=False, null=False)
+    domain = CharField(max_length=200, default="vision")
 
     class Meta:
         table_name = 'brainscore_benchmarktype'

--- a/tests/test_benchmarks/test___init__.py
+++ b/tests/test_benchmarks/test___init__.py
@@ -123,14 +123,6 @@ class TestPoolList:
             'brendel.Geirhos2021uniformnoise-top1',
             'kornblith.Hermann2020cueconflict-shape_bias',
             'kornblith.Hermann2020cueconflict-shape_match',
-            'Islam2021-shape_v1_dimensionality',
-            'Islam2021-texture_v1_dimensionality',
-            'Islam2021-shape_v2_dimensionality',
-            'Islam2021-texture_v2_dimensionality',
-            'Islam2021-shape_v4_dimensionality',
-            'Islam2021-texture_v4_dimensionality',
-            'Islam2021-shape_it_dimensionality',
-            'Islam2021-texture_it_dimensionality',
         }
 
 


### PR DESCRIPTION
This PR moves the `Islam2021` benchmarks from the engineering pool to experimental pool, as well as adding a `domain` to the `BenchmarkType` database table