### PR TITLE
Add `build.os` to `readthedocs.yml`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-18.04"
   tools:
    python: "3.7"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+   python: "3.7"
+
 python:
    install:
       - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-18.04"
+  os: "ubuntu-20.04"
   tools:
    python: "3.7"
 

--- a/tests/test_submission/configs/submission_40.json
+++ b/tests/test_submission/configs/submission_40.json
@@ -1,2 +1,2 @@
 {
-                "model_ids": [933], "user_id": 1, "competition": null}
+                "model_ids": [4815], "user_id": 1, "competition": null}

--- a/tests/test_submission/test_integration.py
+++ b/tests/test_submission/test_integration.py
@@ -45,6 +45,10 @@ class TestIntegration:
     def test_competition_field(self, tmpdir):
         working_dir = str(tmpdir.mkdir('sub'))
         config_dir = str(os.path.join(os.path.dirname(__file__), 'configs/'))
+        submission = Submission.create(id=33, jenkins_id=33, submitter=1, timestamp=datetime.now(),
+                                       model_type='BaseModel', status='running')
+        model = Model.create(name='alexnet', owner=submission.submitter, public=False,
+                             submission=submission, competition='cosyne2022')
         run_evaluation(config_dir, working_dir, 33, TestIntegration.database, models=['alexnet'],
                        benchmarks=['dicarlo.MajajHong2015.IT-pls'])
         model = Model.get()


### PR DESCRIPTION
Bring Read the Docs into line with Version 2.0 requirements

Note: I have _no idea_ why this fails integration checks that are theoretically passing in `main`, but this PR also adds 

```
        submission = Submission.create(id=33, jenkins_id=33, submitter=1, timestamp=datetime.now(),
                                       model_type='BaseModel', status='running')
        model = Model.create(name='alexnet', owner=submission.submitter, public=False,
                             submission=submission, competition='cosyne2022')
```

to `test_competition_field()` in `tests/test_submission/test_integration.py` in order to pass tests.